### PR TITLE
Implement CSV ingestion and price service

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = sqlite:///app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s %(message)s

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+from .db import init_db
+
+init_db()

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,21 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from .models import Base
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite://")
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+    future=True,
+)
+
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def init_db() -> None:
+    Base.metadata.create_all(bind=engine)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import List
+
+from sqlalchemy import (
+    JSON,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class ImportBatch(Base):
+    __tablename__ = "import_batch"
+
+    id = Column(Integer, primary_key=True)
+    source = Column(String, nullable=False)
+    file_name = Column(String, nullable=True)
+    started_at = Column(DateTime(timezone=True), server_default=func.now())
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    rows_ok = Column(Integer, default=0)
+    rows_error = Column(Integer, default=0)
+    warnings = Column(JSON, default=list)
+    notes = Column(Text)
+
+    transactions = relationship("TransactionRaw", back_populates="batch")
+
+
+class TransactionRaw(Base):
+    __tablename__ = "transaction_raw"
+
+    id = Column(Integer, primary_key=True)
+    import_batch_id = Column(Integer, ForeignKey("import_batch.id"), nullable=False)
+    source = Column(String, nullable=False)
+    row_hash = Column(String, unique=True, nullable=False)
+    raw_payload = Column(JSON, nullable=False)
+    error = Column(Text)
+    provenance = Column(JSON, nullable=False)
+
+    batch = relationship("ImportBatch", back_populates="transactions")
+
+
+class PricePoint(Base):
+    __tablename__ = "price_point"
+    __table_args__ = (
+        UniqueConstraint("asset", "quote", "dt_utc", "source", name="uix_pricepoint"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    dt_utc = Column(DateTime(timezone=True), nullable=False)
+    asset = Column(String, nullable=False)
+    quote = Column(String, nullable=False, default="USD")
+    price = Column(Numeric(38, 18), nullable=False)
+    source = Column(String, nullable=False)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,13 @@
+from flask import Flask
+
+from .routes.api import bp as api_bp
+from .routes.ui import bp as ui_bp
+from .db import init_db
+
+
+def create_app() -> Flask:
+    init_db()
+    app = Flask(__name__)
+    app.register_blueprint(api_bp)
+    app.register_blueprint(ui_bp)
+    return app

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import List
+
+from flask import Blueprint, abort, jsonify, request
+
+from app.db import SessionLocal
+from app.db.models import ImportBatch
+from app.services.ingest import dexscreener_csv, token_tx_csv, wallet_tx_csv
+
+bp = Blueprint("api", __name__)
+
+
+@bp.route("/api/import/csv", methods=["POST"])
+def import_csv():
+    source = request.args.get("source")
+    if not source:
+        abort(400)
+
+    files = request.files.getlist("file") or request.files.getlist("files")
+    if not files:
+        abort(400)
+
+    session = SessionLocal()
+    batch = ImportBatch(source=f"{source.upper()}_CSV", file_name=",".join(f.filename or getattr(f, "name", "") for f in files), started_at=datetime.utcnow())
+    session.add(batch)
+    session.commit()
+
+    if source == "token":
+        result = token_tx_csv.parse(files[0], batch.id)
+    elif source == "wallet":
+        result = wallet_tx_csv.parse(files, batch.id)
+    elif source == "dexscreener":
+        result = dexscreener_csv.parse(files[0], batch.id)
+    else:
+        abort(400)
+
+    batch.completed_at = datetime.utcnow()
+    batch.rows_ok = result["rows_ok"]
+    batch.rows_error = result["rows_error"]
+    batch.warnings = result["warnings"]
+    session.commit()
+    session.close()
+
+    logging.info(json.dumps({
+        "batch_id": batch.id,
+        "source": source,
+        "rows_ok": batch.rows_ok,
+        "rows_error": batch.rows_error,
+        "warnings": batch.warnings,
+    }))
+
+    return jsonify({"batch_id": batch.id, **result})

--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -1,0 +1,13 @@
+from flask import Blueprint, render_template
+
+bp = Blueprint("ui", __name__)
+
+
+@bp.route("/")
+def index():
+    return render_template("index.html")
+
+
+@bp.route("/import")
+def import_page():
+    return render_template("import.html")

--- a/app/services/ingest/__init__.py
+++ b/app/services/ingest/__init__.py
@@ -1,0 +1,3 @@
+from . import token_tx_csv, wallet_tx_csv, dexscreener_csv
+
+__all__ = ["token_tx_csv", "wallet_tx_csv", "dexscreener_csv"]

--- a/app/services/ingest/base.py
+++ b/app/services/ingest/base.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import List, Protocol, TypedDict, IO
+
+
+class IngestResult(TypedDict):
+    rows_ok: int
+    rows_error: int
+    warnings: List[str]
+    batch_id: int
+
+
+class CsvParser(Protocol):
+    def parse(self, file: IO, import_batch_id: int) -> IngestResult:
+        ...

--- a/app/services/ingest/dexscreener_csv.py
+++ b/app/services/ingest/dexscreener_csv.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import csv
+from datetime import timezone
+from decimal import Decimal
+from typing import IO
+
+from dateutil import parser as dtparser
+
+from app.db import SessionLocal
+from app.db.models import PricePoint
+from .base import IngestResult
+
+
+def parse(file: IO, import_batch_id: int) -> IngestResult:
+    reader = csv.DictReader(file)
+    session = SessionLocal()
+    rows_ok = 0
+    rows_error = 0
+    warnings = []
+
+    for idx, row in enumerate(reader, start=1):
+        try:
+            dt = dtparser.parse(row.get("timestamp") or row.get("dt"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            dt_utc = dt.astimezone(timezone.utc)
+            token = row.get("token") or row.get("token_symbol")
+            price_usd = row.get("price_usd") or row.get("price")
+            if price_usd:
+                price = Decimal(price_usd)
+                exists = (
+                    session.query(PricePoint)
+                    .filter_by(asset=token, quote="USD", dt_utc=dt_utc, source="DEXSCREENER")
+                    .first()
+                )
+                if not exists:
+                    session.add(
+                        PricePoint(
+                            dt_utc=dt_utc,
+                            asset=token,
+                            quote="USD",
+                            price=price,
+                            source="DEXSCREENER",
+                        )
+                    )
+            price_bnb = row.get("price_in_bnb")
+            if price_bnb:
+                price = Decimal(price_bnb)
+                exists = (
+                    session.query(PricePoint)
+                    .filter_by(asset=token, quote="BNB", dt_utc=dt_utc, source="DEXSCREENER")
+                    .first()
+                )
+                if not exists:
+                    session.add(
+                        PricePoint(
+                            dt_utc=dt_utc,
+                            asset=token,
+                            quote="BNB",
+                            price=price,
+                            source="DEXSCREENER",
+                        )
+                    )
+            rows_ok += 1
+        except Exception as exc:  # pragma: no cover
+            rows_error += 1
+            warnings.append(str(exc))
+
+    session.commit()
+    session.close()
+    return IngestResult(rows_ok=rows_ok, rows_error=rows_error, warnings=warnings, batch_id=import_batch_id)

--- a/app/services/ingest/token_tx_csv.py
+++ b/app/services/ingest/token_tx_csv.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import csv
+import json
+from datetime import timezone
+from hashlib import sha256
+from typing import IO
+
+from dateutil import parser as dtparser
+from decimal import Decimal
+
+from app.db import SessionLocal
+from app.db.models import TransactionRaw
+from .base import IngestResult
+from app.services.normalize.schema import Transaction
+
+
+def parse(file: IO, import_batch_id: int) -> IngestResult:
+    reader = csv.DictReader(file)
+    session = SessionLocal()
+    rows_ok = 0
+    rows_error = 0
+    warnings = []
+
+    for idx, row in enumerate(reader, start=1):
+        try:
+            dt = dtparser.parse(row["timestamp"])
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            dt_utc = dt.astimezone(timezone.utc)
+            amount = Decimal(row["value"])
+            canonical = {
+                "tx_hash": row["tx_hash"],
+                "datetime_utc": dt_utc.isoformat(),
+                "from": row["from"],
+                "to": row["to"],
+                "value": str(amount),
+                "token_symbol": row.get("token_symbol"),
+                "token_contract": row.get("token_contract"),
+            }
+            row_hash = sha256(json.dumps(canonical, sort_keys=True).encode()).hexdigest()
+            exists = session.query(TransactionRaw).filter_by(row_hash=row_hash).first()
+            if exists:
+                continue
+            tx = Transaction(
+                tx_hash=row["tx_hash"],
+                datetime_utc=dt_utc,
+                type="TRANSFER",
+                base_asset=row.get("token_symbol"),
+                base_qty=amount,
+                provenance={"source": "token_csv"},
+            )
+            tr = TransactionRaw(
+                import_batch_id=import_batch_id,
+                source="TOKEN_CSV",
+                row_hash=row_hash,
+                raw_payload=row,
+                provenance={
+                    "source_file": getattr(file, "name", ""),
+                    "row_number": idx,
+                    "normalized": json.loads(tx.json()),
+                },
+            )
+            session.add(tr)
+            rows_ok += 1
+        except Exception as exc:  # pragma: no cover - generic error catch
+            rows_error += 1
+            warnings.append(str(exc))
+
+    session.commit()
+    session.close()
+    return IngestResult(rows_ok=rows_ok, rows_error=rows_error, warnings=warnings, batch_id=import_batch_id)

--- a/app/services/ingest/wallet_tx_csv.py
+++ b/app/services/ingest/wallet_tx_csv.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import csv
+import json
+from datetime import timezone
+from hashlib import sha256
+from typing import IO, Iterable
+
+from dateutil import parser as dtparser
+from decimal import Decimal
+
+from app.db import SessionLocal
+from app.db.models import TransactionRaw
+from .base import IngestResult
+from app.services.normalize.schema import Transaction
+
+
+def parse(files: Iterable[IO], import_batch_id: int) -> IngestResult:
+    session = SessionLocal()
+    rows_ok = 0
+    rows_error = 0
+    warnings = []
+    seen_hashes = set()
+
+    for file in files:
+        reader = csv.DictReader(file)
+        for idx, row in enumerate(reader, start=1):
+            try:
+                dt = dtparser.parse(row.get("DateTime") or row.get("timestamp") or row.get("timeStamp"))
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                dt_utc = dt.astimezone(timezone.utc)
+                amount_str = row.get("Value") or row.get("value") or row.get("TokenValue") or row.get("token_value") or "0"
+                amount = Decimal(amount_str)
+                canonical = {
+                    "tx_hash": row.get("Txhash") or row.get("hash") or row.get("tx_hash"),
+                    "datetime_utc": dt_utc.isoformat(),
+                    "from": row.get("From"),
+                    "to": row.get("To"),
+                    "value": str(amount),
+                    "token_symbol": row.get("TokenSymbol"),
+                }
+                row_hash = sha256(json.dumps(canonical, sort_keys=True).encode()).hexdigest()
+                if row_hash in seen_hashes:
+                    continue
+                seen_hashes.add(row_hash)
+                exists = session.query(TransactionRaw).filter_by(row_hash=row_hash).first()
+                if exists:
+                    continue
+                tx = Transaction(
+                    tx_hash=canonical["tx_hash"],
+                    datetime_utc=dt_utc,
+                    type="TRANSFER",
+                    base_asset=canonical.get("token_symbol"),
+                    base_qty=amount,
+                    provenance={"source": "wallet_csv"},
+                )
+                tr = TransactionRaw(
+                    import_batch_id=import_batch_id,
+                    source="WALLET_CSV",
+                    row_hash=row_hash,
+                    raw_payload=row,
+                    provenance={
+                        "source_file": getattr(file, "name", ""),
+                        "row_number": idx,
+                        "normalized": json.loads(tx.json()),
+                    },
+                )
+                session.add(tr)
+                rows_ok += 1
+            except Exception as exc:  # pragma: no cover
+                rows_error += 1
+                warnings.append(str(exc))
+
+    session.commit()
+    session.close()
+    return IngestResult(rows_ok=rows_ok, rows_error=rows_error, warnings=warnings, batch_id=import_batch_id)

--- a/app/services/normalize/__init__.py
+++ b/app/services/normalize/__init__.py
@@ -1,0 +1,3 @@
+from .schema import Transaction
+
+__all__ = ["Transaction"]

--- a/app/services/normalize/schema.py
+++ b/app/services/normalize/schema.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+
+class Transaction(BaseModel):
+    tx_id: Optional[str] = None
+    tx_hash: str
+    datetime_utc: datetime
+    platform: Optional[str] = None
+    account: Optional[str] = None
+    chain: Optional[str] = None
+    type: str
+    base_asset: Optional[str] = None
+    base_qty: Optional[Decimal] = None
+    quote_asset: Optional[str] = None
+    quote_qty: Optional[Decimal] = None
+    fee_asset: Optional[str] = None
+    fee_qty: Optional[Decimal] = None
+    price_quote: Optional[Decimal] = None
+    note: Optional[str] = None
+    provenance: dict
+
+    @validator("datetime_utc", pre=True)
+    def _parse_datetime(cls, v):
+        if isinstance(v, datetime):
+            dt = v
+        else:
+            dt = datetime.fromisoformat(str(v))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    @validator("base_qty", "quote_qty", "fee_qty", "price_quote", pre=True)
+    def _parse_decimal(cls, v):
+        if v in (None, ""):
+            return None
+        return Decimal(str(v))
+
+    class Config:
+        json_encoders = {Decimal: lambda x: str(x)}

--- a/app/services/prices/__init__.py
+++ b/app/services/prices/__init__.py
@@ -1,0 +1,3 @@
+from .service import PriceService, PriceNotFound
+
+__all__ = ["PriceService", "PriceNotFound"]

--- a/app/services/prices/bscscan.py
+++ b/app/services/prices/bscscan.py
@@ -1,0 +1,9 @@
+from decimal import Decimal
+
+
+class BscScanPriceService:
+    @staticmethod
+    def get_bnb_price() -> Decimal:
+        """Fetch current BNB price in USD.
+        Placeholder to be monkeypatched in tests."""
+        raise RuntimeError("BscScan service not configured")

--- a/app/services/prices/service.py
+++ b/app/services/prices/service.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from app.db import SessionLocal
+from app.db.models import PricePoint
+from .bscscan import BscScanPriceService
+
+
+class PriceNotFound(Exception):
+    pass
+
+
+class PriceService:
+    @staticmethod
+    def get_usd(asset: str, ts: datetime) -> Decimal:
+        session = SessionLocal()
+        start = ts - timedelta(days=1)
+        end = ts + timedelta(days=1)
+        points = (
+            session.query(PricePoint)
+            .filter(PricePoint.asset == asset)
+            .filter(PricePoint.quote == "USD")
+            .filter(PricePoint.dt_utc >= start)
+            .filter(PricePoint.dt_utc <= end)
+            .all()
+        )
+        if points:
+            chosen = min(points, key=lambda p: abs(p.dt_utc - ts))
+            logging.info("price-source=csv asset=%s ts=%s", asset, chosen.dt_utc)
+            session.close()
+            return Decimal(chosen.price)
+
+        if asset.upper() == "BNB":
+            price = BscScanPriceService.get_bnb_price()
+            logging.info("price-source=live-bscscan asset=BNB")
+            session.close()
+            return price
+
+        points = (
+            session.query(PricePoint)
+            .filter(PricePoint.asset == asset)
+            .filter(PricePoint.quote == "BNB")
+            .filter(PricePoint.dt_utc >= start)
+            .filter(PricePoint.dt_utc <= end)
+            .all()
+        )
+        session.close()
+        if points:
+            chosen = min(points, key=lambda p: abs(p.dt_utc - ts))
+            bnb_usd = BscScanPriceService.get_bnb_price()
+            price_usd = Decimal(chosen.price) * Decimal(bnb_usd)
+            logging.info("price-source=csv-bnb asset=%s ts=%s", asset, chosen.dt_utc)
+            return price_usd
+
+        raise PriceNotFound(f"{asset} @ {ts}")

--- a/app/templates/import.html
+++ b/app/templates/import.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>Import</title>
+<h1>CSV Import</h1>
+<form action="/api/import/csv" method="post" enctype="multipart/form-data">
+    <label>Source:
+        <select name="source">
+            <option value="token">Token</option>
+            <option value="wallet">Wallet</option>
+            <option value="dexscreener">DexScreener</option>
+        </select>
+    </label>
+    <br/>
+    <input type="file" name="file" multiple>
+    <br/>
+    <input type="submit" value="Upload">
+</form>
+<div id="results"></div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>Home</title>
+<a href="/import">Import CSV</a>

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,27 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from app.db.models import Base
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+run_migrations_online()

--- a/migrations/versions/0001_init.py
+++ b/migrations/versions/0001_init.py
@@ -1,0 +1,49 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'import_batch',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('source', sa.String(), nullable=False),
+        sa.Column('file_name', sa.String(), nullable=True),
+        sa.Column('started_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('rows_ok', sa.Integer(), nullable=True),
+        sa.Column('rows_error', sa.Integer(), nullable=True),
+        sa.Column('warnings', sa.JSON(), nullable=True),
+        sa.Column('notes', sa.Text(), nullable=True),
+    )
+    op.create_table(
+        'transaction_raw',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('import_batch_id', sa.Integer(), sa.ForeignKey('import_batch.id'), nullable=False),
+        sa.Column('source', sa.String(), nullable=False),
+        sa.Column('row_hash', sa.String(), nullable=False),
+        sa.Column('raw_payload', sa.JSON(), nullable=False),
+        sa.Column('error', sa.Text(), nullable=True),
+        sa.Column('provenance', sa.JSON(), nullable=False),
+        sa.UniqueConstraint('row_hash')
+    )
+    op.create_table(
+        'price_point',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('dt_utc', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('asset', sa.String(), nullable=False),
+        sa.Column('quote', sa.String(), nullable=False, server_default='USD'),
+        sa.Column('price', sa.Numeric(38, 18), nullable=False),
+        sa.Column('source', sa.String(), nullable=False),
+        sa.UniqueConstraint('asset', 'quote', 'dt_utc', 'source', name='uix_pricepoint')
+    )
+
+
+def downgrade():
+    op.drop_table('price_point')
+    op.drop_table('transaction_raw')
+    op.drop_table('import_batch')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+SQLAlchemy
+alembic
+pydantic
+python-dateutil
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+
+from app.main import create_app
+from app.db import SessionLocal, engine
+from app.db.models import Base
+
+
+@pytest.fixture
+def app():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    app = create_app()
+    app.config.update({"TESTING": True})
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def session():
+    with SessionLocal() as session:
+        yield session

--- a/tests/fixtures/dexscreener_sample.csv
+++ b/tests/fixtures/dexscreener_sample.csv
@@ -1,0 +1,3 @@
+timestamp,token,price_usd,price_in_bnb
+2023-09-01T00:00:00Z,TKN,1.0,0.004
+2023-09-01T00:00:00Z,ALT,,0.002

--- a/tests/fixtures/token_tx_sample.csv
+++ b/tests/fixtures/token_tx_sample.csv
@@ -1,0 +1,4 @@
+timestamp,tx_hash,from,to,value,token_symbol,token_contract
+2023-09-01T10:00:00Z,0xhash1,0xfrom1,0xto1,1.23,TKN,0xcontract
+2023-09-02 12:30:00+02:00,0xhash2,0xfrom2,0xto2,2.5,TKN,0xcontract
+2023-09-03 05:00:00-05:00,0xhash3,0xfrom3,0xto3,3.0,TKN,0xcontract

--- a/tests/fixtures/wallet_tx_sample_internal.csv
+++ b/tests/fixtures/wallet_tx_sample_internal.csv
@@ -1,0 +1,2 @@
+Txhash,UnixTimestamp,DateTime,From,To,Value
+0xw1,1693562400,2023-09-01 10:00:00,0xfrom1,0xto1,0

--- a/tests/fixtures/wallet_tx_sample_normal.csv
+++ b/tests/fixtures/wallet_tx_sample_normal.csv
@@ -1,0 +1,3 @@
+Txhash,UnixTimestamp,DateTime,From,To,Value,TokenSymbol
+0xw1,1693562400,2023-09-01 10:00:00,0xfrom1,0xto1,1.0,ETH
+0xw2,1693648800,2023-09-02 10:00:00,0xfrom2,0xto2,2.0,ETH

--- a/tests/fixtures/wallet_tx_sample_tokentx.csv
+++ b/tests/fixtures/wallet_tx_sample_tokentx.csv
@@ -1,0 +1,2 @@
+Txhash,UnixTimestamp,DateTime,From,To,TokenSymbol,TokenValue
+0xw3,1693735200,2023-09-03 10:00:00,0xfrom3,0xto3,TKN,5

--- a/tests/unit/test_api_import.py
+++ b/tests/unit/test_api_import.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from app.db.models import ImportBatch
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def test_api_import_token(client, session):
+    data = {
+        "file": (open(FIXTURES / "token_tx_sample.csv", "rb"), "token.csv"),
+    }
+    resp = client.post("/api/import/csv?source=token", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    js = resp.get_json()
+    assert js["rows_ok"] == 3
+    assert session.query(ImportBatch).count() == 1
+
+
+def test_api_import_wallet(client, session):
+    data = [
+        ("files", (open(FIXTURES / "wallet_tx_sample_normal.csv", "rb"), "n.csv")),
+        ("files", (open(FIXTURES / "wallet_tx_sample_internal.csv", "rb"), "i.csv")),
+        ("files", (open(FIXTURES / "wallet_tx_sample_tokentx.csv", "rb"), "t.csv")),
+    ]
+    resp = client.post("/api/import/csv?source=wallet", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    js = resp.get_json()
+    assert js["rows_ok"] == 3
+    assert session.query(ImportBatch).count() == 1
+
+
+def test_api_import_dex(client, session):
+    data = {
+        "file": (open(FIXTURES / "dexscreener_sample.csv", "rb"), "dex.csv"),
+    }
+    resp = client.post("/api/import/csv?source=dexscreener", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    js = resp.get_json()
+    assert js["rows_ok"] == 2
+    assert session.query(ImportBatch).count() == 1

--- a/tests/unit/test_ingest_token_csv.py
+++ b/tests/unit/test_ingest_token_csv.py
@@ -1,0 +1,33 @@
+from decimal import Decimal
+from pathlib import Path
+
+from app.db.models import ImportBatch, TransactionRaw
+from app.services.ingest import token_tx_csv
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def test_parse_token_csv(session):
+    file_path = FIXTURES / "token_tx_sample.csv"
+    batch = ImportBatch(source="TOKEN_CSV", file_name=file_path.name)
+    session.add(batch)
+    session.commit()
+
+    with open(file_path) as f:
+        result = token_tx_csv.parse(f, batch.id)
+    assert result["rows_ok"] == 3
+    assert result["rows_error"] == 0
+
+    rows = session.query(TransactionRaw).all()
+    assert len(rows) == 3
+    first = rows[0].provenance["normalized"]
+    assert first["datetime_utc"].endswith("+00:00")
+    assert Decimal(first["base_qty"]) == Decimal("1.23")
+
+    batch2 = ImportBatch(source="TOKEN_CSV", file_name=file_path.name)
+    session.add(batch2)
+    session.commit()
+    with open(file_path) as f:
+        result2 = token_tx_csv.parse(f, batch2.id)
+    assert result2["rows_ok"] == 0
+    assert session.query(TransactionRaw).count() == 3

--- a/tests/unit/test_ingest_wallet_csv.py
+++ b/tests/unit/test_ingest_wallet_csv.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from app.db.models import ImportBatch, TransactionRaw
+from app.services.ingest import wallet_tx_csv
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def test_parse_wallet_csv(session):
+    files = [
+        open(FIXTURES / "wallet_tx_sample_normal.csv"),
+        open(FIXTURES / "wallet_tx_sample_internal.csv"),
+        open(FIXTURES / "wallet_tx_sample_tokentx.csv"),
+    ]
+    batch = ImportBatch(source="WALLET_CSV", file_name="multi")
+    session.add(batch)
+    session.commit()
+
+    result = wallet_tx_csv.parse(files, batch.id)
+    for f in files:
+        f.close()
+    assert result["rows_ok"] == 3
+    assert session.query(TransactionRaw).count() == 3
+    first = session.query(TransactionRaw).first()
+    prov = first.provenance
+    assert "source_file" in prov and "row_number" in prov

--- a/tests/unit/test_price_service.py
+++ b/tests/unit/test_price_service.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from app.db.models import ImportBatch
+from app.services.ingest import dexscreener_csv
+from app.services.prices.service import PriceNotFound, PriceService
+from app.services.prices import bscscan
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def load_prices(session):
+    batch = ImportBatch(source="DEXSCREENER_CSV", file_name="dex.csv")
+    session.add(batch)
+    session.commit()
+    with open(FIXTURES / "dexscreener_sample.csv") as f:
+        dexscreener_csv.parse(f, batch.id)
+
+
+def test_price_lookup_from_csv(session):
+    load_prices(session)
+    ts = datetime(2023, 9, 1, 12, tzinfo=timezone.utc)
+    price = PriceService.get_usd("TKN", ts)
+    assert price == Decimal("1.0")
+
+
+def test_price_lookup_bnb_fallback(monkeypatch, session):
+    load_prices(session)
+    monkeypatch.setattr(bscscan.BscScanPriceService, "get_bnb_price", staticmethod(lambda: Decimal("200")))
+    ts = datetime(2023, 9, 1, 12, tzinfo=timezone.utc)
+    price = PriceService.get_usd("ALT", ts)
+    assert price == Decimal("0.4")
+
+
+def test_price_not_found(session):
+    load_prices(session)
+    ts = datetime(2023, 9, 1, 12, tzinfo=timezone.utc)
+    with pytest.raises(PriceNotFound):
+        PriceService.get_usd("MISSING", ts)


### PR DESCRIPTION
## Summary
- add ImportBatch, TransactionRaw, PricePoint models with migration
- implement token, wallet, and DexScreener CSV parsers
- provide price aggregation service with CSV and BNB fallback
- expose `/api/import/csv` and basic `/import` UI
- supply unit tests and CSV fixtures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68ab9a48a178832bb44af3820647400a