### PR TITLE
feat: add condor wallet encoder

### DIFF
--- a/gcc-safeswap/README.md
+++ b/gcc-safeswap/README.md
@@ -15,6 +15,7 @@ The project is organised as a monorepo with separate frontend and backend packag
 * Token swap card supporting BNB, WBNB, GCC, USDT and BTCB.
 * Calls to a backend proxy for 0x pricing/quotes, ApeSwap routing and raw transaction relays.
 * Embedded burner wallet for demo server relays (not for production use).
+* Condor Wallet tool for generating and embedding encrypted wallets into PNG files.
 
 ## Quick Start
 
@@ -54,4 +55,14 @@ The “Use Private RPC” button instructs MetaMask to switch to BNB Chain using
 * GCC gating (NFT or token balance checks) is planned but not yet active.
 
 Screenshots or GIFs should demonstrate the full flow: connect → switch RPC → quote → approve → swap.
+
+## Condor Wallet
+
+The frontend now includes a **Condor Wallet** drawer (Tools → Condor Wallet) for creating ephemeral ECDSA wallets and protecting them with a passphrase.  The backend exposes three routes:
+
+* `POST /api/wallet/generate` – returns a temporary handle, address and fingerprint.
+* `POST /api/wallet/embed` – accepts a PNG, passphrase and handle and streams back a stego PNG containing the encrypted key.
+* `POST /api/wallet/decode` – extracts and decrypts an embedded key from a PNG, returning its address and fingerprint.
+
+Private keys are kept only in memory on the server for up to five minutes and are never logged.  PNG uploads are limited to 5 MB.
 

--- a/gcc-safeswap/packages/backend/package.json
+++ b/gcc-safeswap/packages/backend/package.json
@@ -11,6 +11,8 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "node-fetch": "^3.3.1",
-    "ethers": "^6.6.0"
+    "ethers": "^6.6.0",
+    "multer": "^1.4.5-lts.1",
+    "express-rate-limit": "^6.7.0"
   }
 }

--- a/gcc-safeswap/packages/backend/routes/wallet.js
+++ b/gcc-safeswap/packages/backend/routes/wallet.js
@@ -1,0 +1,101 @@
+const express = require('express');
+const crypto = require('crypto');
+const multer = require('multer');
+const { Wallet } = require('ethers');
+const rateLimit = require('express-rate-limit');
+
+const router = express.Router();
+const upload = multer({ limits: { fileSize: 5 * 1024 * 1024 } });
+
+const store = new Map();
+const TTL = 5 * 60 * 1000; // 5 minutes
+const MARKER = Buffer.from('CONDORWALLET');
+
+function cleanup() {
+  const now = Date.now();
+  for (const [h, { expiry }] of store) {
+    if (expiry < now) store.delete(h);
+  }
+  while (store.size > 256) {
+    const first = store.keys().next().value;
+    store.delete(first);
+  }
+}
+
+router.use(rateLimit({ windowMs: 60 * 1000, max: 20 }));
+
+router.post('/generate', (req, res) => {
+  cleanup();
+  const wallet = Wallet.createRandom();
+  const handle = crypto.randomBytes(8).toString('hex');
+  const pkBuf = Buffer.from(wallet.privateKey.slice(2), 'hex');
+  const hash = crypto.createHash('sha256').update(pkBuf).digest();
+  const fingerprint = hash.slice(0, 4).toString('hex');
+  store.set(handle, { key: wallet.privateKey, expiry: Date.now() + TTL });
+  res.json({ handle, address: wallet.address, fingerprint });
+});
+
+router.post('/embed', upload.single('image'), (req, res) => {
+  try {
+    const { handle, passphrase } = req.body;
+    if (!handle || !passphrase || passphrase.length < 8 || !req.file) {
+      return res.status(400).json({ error: 'invalid input' });
+    }
+    cleanup();
+    const entry = store.get(handle);
+    if (!entry) {
+      return res.status(400).json({ error: 'invalid handle' });
+    }
+    store.delete(handle);
+    const salt = crypto.randomBytes(16);
+    const key = crypto.pbkdf2Sync(passphrase, salt, 200000, 32, 'sha256');
+    const nonce = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, nonce);
+    const pkBuf = Buffer.from(entry.key.slice(2), 'hex');
+    const ct = Buffer.concat([cipher.update(pkBuf), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const payload = JSON.stringify({
+      salt: salt.toString('base64'),
+      nonce: nonce.toString('base64'),
+      tag: tag.toString('base64'),
+      ct: ct.toString('base64')
+    });
+    const out = Buffer.concat([req.file.buffer, MARKER, Buffer.from(payload)]);
+    res.set('Content-Type', 'image/png');
+    res.send(out);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/decode', upload.single('image'), (req, res) => {
+  try {
+    const { passphrase } = req.body;
+    if (!passphrase || passphrase.length < 8 || !req.file) {
+      return res.status(400).json({ error: 'invalid input' });
+    }
+    const buf = req.file.buffer;
+    const idx = buf.lastIndexOf(MARKER);
+    if (idx === -1) {
+      return res.status(400).json({ error: 'no payload' });
+    }
+    const payloadStr = buf.slice(idx + MARKER.length).toString();
+    const payload = JSON.parse(payloadStr);
+    const salt = Buffer.from(payload.salt, 'base64');
+    const nonce = Buffer.from(payload.nonce, 'base64');
+    const tag = Buffer.from(payload.tag, 'base64');
+    const ct = Buffer.from(payload.ct, 'base64');
+    const key = crypto.pbkdf2Sync(passphrase, salt, 200000, 32, 'sha256');
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, nonce);
+    decipher.setAuthTag(tag);
+    const pkBuf = Buffer.concat([decipher.update(ct), decipher.final()]);
+    const privateKey = '0x' + pkBuf.toString('hex');
+    const wallet = new Wallet(privateKey);
+    const fingerprint = crypto.createHash('sha256').update(pkBuf).digest().slice(0, 4).toString('hex');
+    res.json({ address: wallet.address, fingerprint });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/gcc-safeswap/packages/backend/server.cjs
+++ b/gcc-safeswap/packages/backend/server.cjs
@@ -5,7 +5,8 @@ const dotenv = require('dotenv');
 dotenv.config();
 
 const app = express();
-app.use(cors());
+const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN || '*';
+app.use(cors({ origin: FRONTEND_ORIGIN }));
 app.use(express.json());
 
 const PORT = process.env.PORT || 8787;
@@ -17,6 +18,7 @@ app.get('/health', (_, res) => {
 app.use('/api/0x', require('./routes/zeroex'));
 app.use('/api/relay', require('./routes/relay'));
 app.use('/api/apeswap', require('./routes/apeswap'));
+app.use('/api/wallet', require('./routes/wallet'));
 
 app.listen(PORT, () => {
   console.log(`Server running on ${PORT}`);

--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import Connect from './components/Connect.jsx';
 import SafeSwap from './components/SafeSwap.jsx';
+import WalletDrawer from './components/WalletDrawer.jsx';
 import useShieldStatus from './hooks/useShieldStatus.js';
 
 export default function App() {
   const [account, setAccount] = useState(null);
   const { shieldOn, markPrivateUsed, refreshShield } = useShieldStatus();
+  const [walletOpen, setWalletOpen] = useState(false);
 
   useEffect(() => {
     if (!window.ethereum) return;
@@ -49,12 +51,14 @@ export default function App() {
         <div>
           <button onClick={switchRpc}>Use Private RPC</button>
           <Connect account={account} setAccount={setAccount} />
+          <button onClick={() => setWalletOpen(true)}>Condor Wallet</button>
           <span className={`pill ${shieldOn ? 'shield-on' : 'shield-off'}`}>
             {shieldOn ? 'MEV-Shield ON' : 'MEV-Shield OFF'}
           </span>
         </div>
       </header>
       <SafeSwap account={account} />
+      <WalletDrawer open={walletOpen} onClose={() => setWalletOpen(false)} />
     </>
   );
 }

--- a/gcc-safeswap/packages/frontend/src/components/DropZone.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/DropZone.jsx
@@ -1,0 +1,32 @@
+import React, { useRef } from 'react';
+
+export default function DropZone({ onFile }) {
+  const inputRef = useRef(null);
+
+  const handleFiles = (files) => {
+    if (files && files[0] && files[0].type === 'image/png') {
+      onFile(files[0]);
+    }
+  };
+
+  return (
+    <div
+      className="dropzone"
+      onClick={() => inputRef.current && inputRef.current.click()}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={(e) => {
+        e.preventDefault();
+        handleFiles(e.dataTransfer.files);
+      }}
+    >
+      <p>Select or drop PNG</p>
+      <input
+        type="file"
+        accept="image/png"
+        ref={inputRef}
+        style={{ display: 'none' }}
+        onChange={(e) => handleFiles(e.target.files)}
+      />
+    </div>
+  );
+}

--- a/gcc-safeswap/packages/frontend/src/components/Fingerprint.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/Fingerprint.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export default function Fingerprint({ value }) {
+  if (!value) return null;
+  return <span className="fingerprint">{value}</span>;
+}

--- a/gcc-safeswap/packages/frontend/src/components/WalletDrawer.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/WalletDrawer.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import DropZone from './DropZone.jsx';
+import Fingerprint from './Fingerprint.jsx';
+
+export default function WalletDrawer({ open, onClose }) {
+  const [wallet, setWallet] = useState(null);
+  const [pass, setPass] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [file, setFile] = useState(null);
+  const [message, setMessage] = useState('');
+
+  const [dpass, setDpass] = useState('');
+  const [dfile, setDfile] = useState(null);
+  const [decode, setDecode] = useState(null);
+  const [dmsg, setDmsg] = useState('');
+
+  if (!open) return null;
+
+  const generate = async () => {
+    setMessage('');
+    const resp = await fetch('/api/wallet/generate', { method: 'POST' });
+    const data = await resp.json();
+    if (resp.ok) setWallet(data);
+    else setMessage(data.error || 'error');
+  };
+
+  const embed = async () => {
+    if (!wallet || pass.length < 8 || pass !== confirm || !file) {
+      setMessage('Check inputs');
+      return;
+    }
+    const form = new FormData();
+    form.append('handle', wallet.handle);
+    form.append('passphrase', pass);
+    form.append('image', file);
+    const resp = await fetch('/api/wallet/embed', { method: 'POST', body: form });
+    if (!resp.ok) {
+      const err = await resp.json();
+      setMessage(err.error || 'error');
+      return;
+    }
+    const blob = await resp.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `condor_wallet_${wallet.fingerprint}.png`;
+    a.click();
+    URL.revokeObjectURL(url);
+    setWallet(null); setPass(''); setConfirm(''); setFile(null);
+  };
+
+  const decodeCall = async () => {
+    if (dpass.length < 8 || !dfile) {
+      setDmsg('Check inputs');
+      return;
+    }
+    const form = new FormData();
+    form.append('passphrase', dpass);
+    form.append('image', dfile);
+    const resp = await fetch('/api/wallet/decode', { method: 'POST', body: form });
+    const data = await resp.json();
+    if (resp.ok) { setDecode(data); setDmsg(''); }
+    else setDmsg(data.error || 'error');
+  };
+
+  return (
+    <div className="wallet-drawer">
+      <button onClick={onClose} style={{ float: 'right' }}>Close</button>
+      <h2>Condor Wallet</h2>
+      <section>
+        <h3>Create & Embed</h3>
+        <button onClick={generate}>Generate Wallet</button>
+        {wallet && (
+          <div>
+            <div>Address: {wallet.address}</div>
+            <Fingerprint value={wallet.fingerprint} />
+          </div>
+        )}
+        <input type="password" placeholder="Passphrase" value={pass} onChange={(e)=>setPass(e.target.value)} />
+        <input type="password" placeholder="Confirm" value={confirm} onChange={(e)=>setConfirm(e.target.value)} />
+        <DropZone onFile={setFile} />
+        <button onClick={embed}>Embed Key in Image</button>
+        {message && <p className="error">{message}</p>}
+      </section>
+      <hr />
+      <section>
+        <h3>Decode</h3>
+        <input type="password" placeholder="Passphrase" value={dpass} onChange={(e)=>setDpass(e.target.value)} />
+        <DropZone onFile={setDfile} />
+        <button onClick={decodeCall}>Decode</button>
+        {dmsg && <p className="error">{dmsg}</p>}
+        {decode && (
+          <div>
+            <div>Address: {decode.address}</div>
+            <Fingerprint value={decode.fingerprint} />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/gcc-safeswap/packages/frontend/src/styles.css
+++ b/gcc-safeswap/packages/frontend/src/styles.css
@@ -58,3 +58,6 @@ button {
 .toast.success{ border-color:#10b981; }
 .toast.error{ border-color:#ef4444; }
 .error{ color:#fecaca; padding:10px; border:1px solid #7f1d1d; border-radius:8px; background:#450a0a; }
+.wallet-drawer{ position:fixed; top:0; right:0; width:300px; height:100%; background:#111; border-left:1px solid #bfa33a; padding:1rem; overflow:auto; }
+.fingerprint{ display:inline-block; background:#333; padding:2px 4px; margin-left:4px; font-size:0.8rem; }
+.dropzone{ border:1px dashed #334155; padding:1rem; text-align:center; cursor:pointer; margin-top:0.5rem; }


### PR DESCRIPTION
## Summary
- add `/api/wallet` backend with generate, embed, decode endpoints
- store keys in short-lived memory, encrypt with PBKDF2 + AES-GCM and append to PNG
- frontend drawer for Condor Wallet with passphrase protection and PNG drop zone

## Testing
- `npm --prefix gcc-safeswap/packages/backend test` *(fails: Missing script "test")*
- `npm --prefix gcc-safeswap/packages/frontend test` *(fails: Missing script "test")*
- `npm --prefix gcc-safeswap/packages/frontend run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0e420884832b855c92e8e8131735