### PR TITLE
Add server-side Condor wallet unlock and signer integration

### DIFF
--- a/gcc-safeswap/packages/backend/routes/wallet.js
+++ b/gcc-safeswap/packages/backend/routes/wallet.js
@@ -10,6 +10,8 @@ const upload = multer({ limits: { fileSize: 5 * 1024 * 1024 } });
 const store = new Map();
 const TTL = 5 * 60 * 1000; // 5 minutes
 const MARKER = Buffer.from('CONDORWALLET');
+const sessions = new Map();
+const SESS_TTL = 10 * 60 * 1000; // 10 minutes
 
 function cleanup() {
   const now = Date.now();
@@ -19,6 +21,13 @@ function cleanup() {
   while (store.size > 256) {
     const first = store.keys().next().value;
     store.delete(first);
+  }
+}
+
+function sessionCleanup() {
+  const now = Date.now();
+  for (const [id, { exp }] of sessions) {
+    if (exp < now) sessions.delete(id);
   }
 }
 
@@ -96,6 +105,76 @@ router.post('/decode', upload.single('image'), (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
+});
+
+router.post('/unlock', upload.single('image'), (req, res) => {
+  try {
+    const pass = req.body?.passphrase;
+    if (!pass || pass.length < 8 || !req.file) {
+      return res.status(400).json({ error: 'invalid input' });
+    }
+    const buf = req.file.buffer;
+    const idx = buf.lastIndexOf(MARKER);
+    if (idx === -1) {
+      return res.status(400).json({ error: 'no payload' });
+    }
+    const payloadStr = buf.slice(idx + MARKER.length).toString();
+    const payload = JSON.parse(payloadStr);
+    const salt = Buffer.from(payload.salt, 'base64');
+    const nonce = Buffer.from(payload.nonce, 'base64');
+    const tag = Buffer.from(payload.tag, 'base64');
+    const ct = Buffer.from(payload.ct, 'base64');
+    const key = crypto.pbkdf2Sync(pass, salt, 200000, 32, 'sha256');
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, nonce);
+    decipher.setAuthTag(tag);
+    const pkBuf = Buffer.concat([decipher.update(ct), decipher.final()]);
+    const privateKey = '0x' + pkBuf.toString('hex');
+    const wallet = new Wallet(privateKey);
+    const fingerprint = crypto.createHash('sha256').update(pkBuf).digest().slice(0, 4).toString('hex');
+    const sessionId = crypto.randomUUID();
+    sessions.set(sessionId, { pkHex: privateKey, address: wallet.address, exp: Date.now() + SESS_TTL });
+    res.json({ sessionId, address: wallet.address, fingerprint });
+  } catch (err) {
+    res.status(422).json({ error: err.message });
+  } finally {
+    sessionCleanup();
+  }
+});
+
+router.post('/signTransaction', express.json(), async (req, res) => {
+  try {
+    const { sessionId, tx } = req.body || {};
+    sessionCleanup();
+    const sess = sessions.get(sessionId);
+    if (!sess) return res.status(404).json({ error: 'session expired' });
+    const signer = new Wallet(sess.pkHex);
+    if (tx.chainId == null) tx.chainId = 56;
+    const rawTx = await signer.signTransaction(tx);
+    res.json({ rawTx });
+  } catch (err) {
+    res.status(422).json({ error: err.message });
+  }
+});
+
+router.post('/signTypedData', express.json(), async (req, res) => {
+  try {
+    const { sessionId, domain, types, message } = req.body || {};
+    sessionCleanup();
+    const sess = sessions.get(sessionId);
+    if (!sess) return res.status(404).json({ error: 'session expired' });
+    const signer = new Wallet(sess.pkHex);
+    const signature = await signer.signTypedData(domain, types, message);
+    res.json({ signature });
+  } catch (err) {
+    res.status(422).json({ error: err.message });
+  }
+});
+
+router.post('/destroy', express.json(), (req, res) => {
+  const { sessionId } = req.body || {};
+  sessions.delete(sessionId);
+  sessionCleanup();
+  res.json({ ok: true });
 });
 
 module.exports = router;

--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -1,13 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import Connect from './components/Connect.jsx';
 import SafeSwap from './components/SafeSwap.jsx';
-import WalletDrawer from './components/WalletDrawer.jsx';
+import UnlockModal from './components/UnlockModal.jsx';
 import useShieldStatus from './hooks/useShieldStatus.js';
+import { ServerSigner } from './lib/serverSigner.js';
 
 export default function App() {
   const [account, setAccount] = useState(null);
   const { shieldOn, markPrivateUsed, refreshShield } = useShieldStatus();
-  const [walletOpen, setWalletOpen] = useState(false);
+  const [unlockOpen, setUnlockOpen] = useState(false);
+  const [serverWallet, setServerWallet] = useState(null);
+  const [useServer, setUseServer] = useState(false);
 
   useEffect(() => {
     if (!window.ethereum) return;
@@ -41,6 +44,9 @@ export default function App() {
     }
   };
 
+  const activeAccount = useServer && serverWallet ? serverWallet.address : account;
+  const signer = useServer && serverWallet ? new ServerSigner(serverWallet.sessionId, serverWallet.address) : null;
+
   return (
     <>
       <header>
@@ -51,14 +57,20 @@ export default function App() {
         <div>
           <button onClick={switchRpc}>Use Private RPC</button>
           <Connect account={account} setAccount={setAccount} />
-          <button onClick={() => setWalletOpen(true)}>Condor Wallet</button>
+          <button onClick={() => setUnlockOpen(true)}>Unlock Condor Wallet</button>
           <span className={`pill ${shieldOn ? 'shield-on' : 'shield-off'}`}>
             {shieldOn ? 'MEV-Shield ON' : 'MEV-Shield OFF'}
           </span>
         </div>
       </header>
-      <SafeSwap account={account} />
-      <WalletDrawer open={walletOpen} onClose={() => setWalletOpen(false)} />
+      <SafeSwap account={activeAccount} serverSigner={signer} />
+      <UnlockModal
+        open={unlockOpen}
+        onClose={() => setUnlockOpen(false)}
+        onUnlocked={setServerWallet}
+        onUseForSigning={setUseServer}
+        onDestroy={() => setServerWallet(null)}
+      />
     </>
   );
 }

--- a/gcc-safeswap/packages/frontend/src/components/UnlockModal.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/UnlockModal.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import DropZone from './DropZone.jsx';
+import Fingerprint from './Fingerprint.jsx';
+
+export default function UnlockModal({ open, onClose, onUnlocked, onUseForSigning, onDestroy }) {
+  const [file, setFile] = useState(null);
+  const [pass, setPass] = useState('');
+  const [msg, setMsg] = useState('');
+  const [wallet, setWallet] = useState(null);
+  const [useSigner, setUseSigner] = useState(false);
+
+  if (!open) return null;
+
+  const unlock = async () => {
+    setMsg('');
+    if (!file || pass.length < 8) {
+      setMsg('Check inputs');
+      return;
+    }
+    const form = new FormData();
+    form.append('image', file);
+    form.append('passphrase', pass);
+    const resp = await fetch('/api/wallet/unlock', { method: 'POST', body: form });
+    const data = await resp.json();
+    if (!resp.ok || data.error) {
+      setMsg(data.error || 'error');
+      return;
+    }
+    setWallet(data);
+    onUnlocked && onUnlocked(data);
+  };
+
+  const toggleUse = (e) => {
+    const v = e.target.checked;
+    setUseSigner(v);
+    onUseForSigning && onUseForSigning(v);
+  };
+
+  const destroy = async () => {
+    if (wallet) {
+      await fetch('/api/wallet/destroy', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ sessionId: wallet.sessionId }) });
+    }
+    setWallet(null);
+    setFile(null);
+    setPass('');
+    setUseSigner(false);
+    onUseForSigning && onUseForSigning(false);
+    onDestroy && onDestroy();
+  };
+
+  return (
+    <div className="wallet-drawer">
+      <button onClick={onClose} style={{ float: 'right' }}>Close</button>
+      <h2>Unlock Condor Wallet</h2>
+      <input type="password" placeholder="Passphrase" value={pass} onChange={e => setPass(e.target.value)} />
+      <DropZone onFile={setFile} />
+      <button onClick={unlock}>Unlock</button>
+      {msg && <p className="error">{msg}</p>}
+      {wallet && (
+        <div>
+          <p>Unlocked • {wallet.address.slice(0, 6)}…{wallet.address.slice(-4)}</p>
+          <Fingerprint value={wallet.fingerprint} />
+          <label>
+            <input type="checkbox" checked={useSigner} onChange={toggleUse} /> Use as Signing Wallet
+          </label>
+          <button onClick={destroy}>Lock &amp; Destroy</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gcc-safeswap/packages/frontend/src/hooks/useAllowance.js
+++ b/gcc-safeswap/packages/frontend/src/hooks/useAllowance.js
@@ -1,7 +1,24 @@
-import { BrowserProvider, Contract, ethers } from "ethers";
+import { BrowserProvider, Contract, ethers, Interface } from "ethers";
+import { getRpcProvider } from "../lib/ethers";
+
 export default function useAllowance() {
-  async function ensure({ tokenAddr, owner, spender, amount, approveMax }) {
+  async function ensure({ tokenAddr, owner, spender, amount, approveMax, serverSigner }) {
     if (!tokenAddr || tokenAddr.toLowerCase()==="0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") return true;
+    if (serverSigner) {
+      const provider = getRpcProvider();
+      const erc20 = new Contract(tokenAddr, ["function allowance(address owner, address spender) view returns (uint256)"], provider);
+      const cur = await erc20.allowance(owner, spender);
+      if (cur >= amount) return true;
+      const value = approveMax ? ethers.MaxUint256 : amount;
+      const iface = new Interface(["function approve(address spender, uint256 value)"]);
+      const data = iface.encodeFunctionData("approve", [spender, value]);
+      const tx = { to: tokenAddr, data, value: 0, chainId: 56 };
+      const rawTx = await serverSigner.signTransaction(tx);
+      const resp = await fetch('/api/relay/sendRaw', { method: 'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ rawTx }) });
+      const j = await resp.json();
+      if (!resp.ok || j.error) throw new Error(j.error || 'relay failed');
+      return true;
+    }
     const prov = new BrowserProvider(window.ethereum); const signer = await prov.getSigner();
     const erc20 = new Contract(tokenAddr, [
       "function allowance(address owner, address spender) view returns (uint256)",

--- a/gcc-safeswap/packages/frontend/src/lib/serverSigner.js
+++ b/gcc-safeswap/packages/frontend/src/lib/serverSigner.js
@@ -1,0 +1,32 @@
+export class ServerSigner {
+  constructor(sessionId, address) {
+    this.sessionId = sessionId;
+    this._address = address;
+  }
+
+  async getAddress() {
+    return this._address;
+  }
+
+  async signTransaction(tx) {
+    const resp = await fetch('/api/wallet/signTransaction', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: this.sessionId, tx })
+    });
+    const data = await resp.json();
+    if (!resp.ok || data.error) throw new Error(data.error || 'sign failed');
+    return data.rawTx;
+  }
+
+  async signTypedData(domain, types, message) {
+    const resp = await fetch('/api/wallet/signTypedData', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: this.sessionId, domain, types, message })
+    });
+    const data = await resp.json();
+    if (!resp.ok || data.error) throw new Error(data.error || 'sign failed');
+    return data.signature;
+  }
+}


### PR DESCRIPTION
## Summary
- Add backend wallet session routes to unlock PNG-stego wallets, sign transactions/typed data, and destroy sessions
- Introduce ServerSigner and UnlockModal to use server-held wallets in frontend
- Extend SafeSwap and allowance logic to sign approvals and swaps via backend sessions

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run build` (frontend) *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd100562d8832b826252a9a62782f0