### PR TITLE
Refine SafeSwap hero layout and logo sizing

### DIFF
--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -49,8 +49,8 @@ export default function App() {
 
       <header className="nav">
         <div className="nav__inner container">
-          <a href="/" className="brand">
-            <img src="/assets/logo.jpeg" alt="Condor Logo" />
+          <a href="/" className="brand" aria-label="GCC SafeSwap Home">
+            <img src="/assets/logo.jpeg" alt="Condor Logo" className="logo" />
             <span>GCC SafeSwap</span>
           </a>
           <div className="nav__links">
@@ -70,11 +70,11 @@ export default function App() {
             <button className="btn btn--primary" onClick={scrollToSwap}>Start Swapping</button>
           </div>
         </div>
-        <div className="hero__visual">
+        {/* <div className="hero__visual">
           <div className="holo">
-            <img src="/assets/matrix.png" alt="Condor" className="condor-visual"/>
+            <img src="/assets/matrix.png" alt="Condor" className="condor-visual" />
           </div>
-        </div>
+        </div> */}
       </section>
 
       <main>

--- a/gcc-safeswap/packages/frontend/src/styles.css
+++ b/gcc-safeswap/packages/frontend/src/styles.css
@@ -42,8 +42,9 @@ main{ flex:1; }
 input, select, button { font-size:16px; -webkit-tap-highlight-color: transparent; }
 
 /* ---------- Background (matrix) ---------- */
-.bg-overlay{ position:fixed; inset:0; overflow:hidden; z-index:-1; }
+.bg-overlay{ position:fixed; inset:0; z-index:-1; }
 .bg-matrix{
+  z-index:-1;
   width:100%; height:100%;
   background:
     linear-gradient(rgba(0,0,0,.55), rgba(0,0,0,.85)),
@@ -74,8 +75,11 @@ header.nav{
 }
 .brand{ display:flex; gap:10px; align-items:center; font-weight:700; letter-spacing:.3px; }
 .brand .logo{
-  width:22px; height:22px; display:inline-grid; place-items:center;
-  color:var(--cyan); filter:drop-shadow(0 0 6px var(--cyan));
+  width:28px;
+  height:28px;
+  border-radius:6px;
+  object-fit:cover;
+  display:block;
 }
 .nav__links{ list-style:none; display:flex; gap:22px; margin:0; padding:0; }
 .nav__links a{ color:var(--ink); opacity:.92; text-decoration:none; transition:color var(--transition), opacity var(--transition); }
@@ -124,6 +128,7 @@ button[aria-busy="true"]::after{
   padding:18px;
   color:var(--ink);
   border:1px solid var(--border);
+  box-shadow: 0 20px 60px rgba(0,0,0,.45), 0 0 0 1px rgba(0,255,255,.08) inset;
 }
 
 /* stats ribbon */
@@ -173,6 +178,15 @@ button[aria-busy="true"]::after{
 .fingerprint{ display:inline-block; background:#333; padding:2px 6px; margin-left:6px; font-size:.80rem; border-radius:6px; }
 .dropzone{ border:1px dashed #334155; padding:1rem; text-align:center; cursor:pointer; margin-top:.5rem; border-radius:10px; }
 
+/* Bring the swap UI to the front */
+.holo, .hero, main, header.nav, .footer { position: relative; z-index: 1; }
+
+/* Make the foreground hero image go away */
+.hero__visual { display: none; }
+
+/* Tighten hero spacing */
+.hero{ padding:36px 0 8px; }
+
 /* ---------- Footer ---------- */
 footer{ margin-top:auto; }
 .footer{ padding:14px 0; border-top:1px solid var(--line); }
@@ -204,7 +218,7 @@ footer{ margin-top:auto; }
   .holo{ max-width:100%; margin:24px auto; border-radius:14px; }
   .holo .card{ padding:16px; }
   .footer__inner{ flex-direction:column; gap:8px; text-align:center; }
-  .brand .logo{ width:20px; height:20px; }
+  .brand .logo{ width:22px; height:22px; }
   .brand{ font-size:1rem; }
   .nav__links{ gap:14px; }
   .subtitle{ font-size:.95rem; }


### PR DESCRIPTION
## Summary
- Resize header logo and ensure it appears with proper class
- Push matrix background behind swap card and remove foreground hero image
- Add box shadow and higher z-index so swap card sits above background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found, dependencies blocked during install)*

------
https://chatgpt.com/codex/tasks/task_e_68bf60c54030832bb30a110e1c5d9eaa