### PR TITLE
feat: add dex swap builder and harden backend

### DIFF
--- a/gcc-safeswap/packages/backend/lib/routers.cjs
+++ b/gcc-safeswap/packages/backend/lib/routers.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  PANCAKE: {
+    ROUTER: "0x10ED43C718714eb63d5aA57B78B54704E256024E",
+    // Methods: swapExactTokensForETHSupportingFeeOnTransferTokens, swapExactETHForTokensSupportingFeeOnTransferTokens
+  },
+  APESWAP: {
+    ROUTER: "0x325E343f1d39Ff2816dCB1d8621e8e5E4BfB1B6A"
+  },
+  WBNB:  "0xBB4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
+};

--- a/gcc-safeswap/packages/backend/routes/swap.js
+++ b/gcc-safeswap/packages/backend/routes/swap.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const { ethers } = require('ethers');
+const { PANCAKE, APESWAP, WBNB } = require('../lib/routers.cjs');
+
+const router = express.Router();
+const routerAbi = [
+  "function swapExactTokensForETHSupportingFeeOnTransferTokens(uint amountIn, uint amountOutMin, address[] path, address to, uint deadline)",
+  "function swapExactETHForTokensSupportingFeeOnTransferTokens(uint amountOutMin, address[] path, address to, uint deadline) payable",
+  "function swapExactTokensForTokensSupportingFeeOnTransferTokens(uint amountIn, uint amountOutMin, address[] path, address to, uint deadline)"
+];
+
+router.post('/build', async (req, res) => {
+  try {
+    const { account, routerAddr, path, sellAmount, buyAmount, slippageBps=200, reflectionBps=100 } = req.body || {};
+    if (!account || !routerAddr || !Array.isArray(path)) return res.status(400).json({ error:"missing params" });
+
+    // minOut includes slippage + reflection buffer
+    const minOut = (BigInt(buyAmount) * BigInt(10_000 - slippageBps) / 10_000n) * BigInt(10_000 - reflectionBps) / 10_000n;
+
+    const iface = new ethers.Interface(routerAbi);
+    const deadline = Math.floor(Date.now()/1000) + 60*10; // 10m
+
+    let to, data, value = "0x0";
+    const sellsNative = /^0xEeee/i.test(path[0]) || path[0] === 'BNB';
+    const buysNative  = /^0xEeee/i.test(path[path.length-1]) || path[path.length-1] === 'BNB';
+
+    const finalPath = path.map(a => /^0xEeee/i.test(a) || a === 'BNB' ? WBNB : a);
+
+    if (sellsNative) {
+      data = iface.encodeFunctionData(
+        "swapExactETHForTokensSupportingFeeOnTransferTokens",
+        [minOut.toString(), finalPath, account, deadline]
+      );
+      value = ethers.toBeHex(sellAmount);
+    } else if (buysNative) {
+      data = iface.encodeFunctionData(
+        "swapExactTokensForETHSupportingFeeOnTransferTokens",
+        [sellAmount, minOut.toString(), finalPath, account, deadline]
+      );
+    } else {
+      data = iface.encodeFunctionData(
+        "swapExactTokensForTokensSupportingFeeOnTransferTokens",
+        [sellAmount, minOut.toString(), finalPath, account, deadline]
+      );
+    }
+
+    res.json({ to: routerAddr, data, value, minOut: minOut.toString() });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+module.exports = router;

--- a/gcc-safeswap/packages/backend/server.cjs
+++ b/gcc-safeswap/packages/backend/server.cjs
@@ -1,13 +1,20 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
+const rateLimit = require('express-rate-limit');
 
 dotenv.config();
 
 const app = express();
-const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN || '*';
-app.use(cors({ origin: FRONTEND_ORIGIN }));
-app.use(express.json());
+app.use(cors({
+  origin: [
+    'http://localhost:5173',
+    process.env.FRONTEND_ORIGIN // optional
+  ].filter(Boolean),
+  methods: ['GET','POST'],
+}));
+app.use(express.json({ limit: "1mb" }));
+app.use(rateLimit({ windowMs: 60_000, max: 120, standardHeaders: true }));
 
 function reqLog(req, res, next) {
   const t0 = Date.now();
@@ -19,18 +26,35 @@ function reqLog(req, res, next) {
 }
 app.use(reqLog);
 
+// tiny guard middleware
+app.use('/api', (req,res,next)=>{
+  const q = { ...req.query, ...req.body };
+  if (q.sellAmount && !/^\d+$/.test(String(q.sellAmount))) {
+    return res.status(400).json({ error: "invalid sellAmount" });
+  }
+  next();
+});
+
 const PORT = process.env.PORT || 8787;
 
 app.get('/health', (_, res) => {
   res.json({ ok: true, ts: Date.now() });
 });
 
-app.use('/api/0x', require('./routes/zeroex'));
-app.use('/api/relay', require('./routes/relay'));
-app.use('/api/apeswap', require('./routes/apeswap'));
-app.use('/api/wallet', require('./routes/wallet'));
-app.use('/api/dex', require('./routes/dex'));
+const zeroex = require('./routes/zeroex');
+const relay = require('./routes/relay');
+const apeswap = require('./routes/apeswap');
+const wallet = require('./routes/wallet');
+const dex = require('./routes/dex.js');
+const swap = require('./routes/swap.js');
 const pluginsRouter = require('./routes/plugins');
+
+app.use('/api/0x', zeroex);
+app.use('/api/relay', relay);
+app.use('/api/apeswap', apeswap);
+app.use('/api/wallet', wallet);
+app.use('/api/dex', dex);
+app.use('/api/swap', swap);
 // Plugin routes are mounted under /api/plugins
 app.use('/api/plugins', pluginsRouter);
 


### PR DESCRIPTION
## Summary
- add router constants and new DEX quote implementation
- expose swap builder for fee-on-transfer tokens
- tighten server with CORS allowlist, rate limits, and basic input validation

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (root) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf84f67d2c832b8708f61b665f82af