### PR TITLE
Normalize native BNB to WBNB in quoting routes

### DIFF
--- a/gcc-safeswap/packages/backend/routes/dex.js
+++ b/gcc-safeswap/packages/backend/routes/dex.js
@@ -1,8 +1,26 @@
 const express = require('express');
 const { ethers } = require('ethers');
-const { PANCAKE, APESWAP, WBNB } = require('../lib/routers.cjs');
+const { PANCAKE, APESWAP } = require('../lib/routers.cjs');
 
 const router = express.Router();
+
+const CHAIN_BSC = 56;
+const WBNB = "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c";
+const NATIVE_SENTINEL = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+function normalizeToken(addrOrSymbol, chainId) {
+  if (!addrOrSymbol) return addrOrSymbol;
+  const s = String(addrOrSymbol).toLowerCase();
+  const isNative = s === 'bnb' || s === NATIVE_SENTINEL;
+  if (Number(chainId) === CHAIN_BSC && isNative) return WBNB;
+  return addrOrSymbol;
+}
+
+function isNative(addrOrSymbol) {
+  if (!addrOrSymbol) return false;
+  const s = String(addrOrSymbol).toLowerCase();
+  return s === 'bnb' || s === NATIVE_SENTINEL;
+}
 
 // very small ABI surface
 const pairAbi = ["function getReserves() view returns (uint112,uint112,uint32)"];
@@ -12,31 +30,36 @@ const routerAbi = [
 ];
 
 // Helpers
-function isNative(addr){ return /^0xEeee/i.test(addr) || addr === 'BNB'; }
 function toHex(v){ return ethers.toBeHex(v); }
 
 router.get('/quote', async (req, res) => {
   try {
-    const { chainId="56", sellToken, buyToken, sellAmount } = req.query;
-    if (chainId !== "56") return res.status(400).json({ error: "Only BNB Chain (56) supported" });
+    const chainId = Number(req.query.chainId || CHAIN_BSC);
+    if (chainId !== CHAIN_BSC) return res.status(400).json({ error: 'Only BNB Chain (56) supported' });
 
     const rpc = process.env.PRIVATE_RPC_URL;
     const provider = new ethers.JsonRpcProvider(rpc, 56);
 
-    const sellsNative = isNative(sellToken);
-    const buysNative  = isNative(buyToken);
-    const sellAddr = sellsNative ? WBNB : sellToken;
-    const buyAddr  = buysNative ? WBNB : (buyToken === 'BNB' ? WBNB : buyToken);
+    const sellTokenRaw = req.query.sellToken;
+    const buyTokenRaw  = req.query.buyToken;
+    const sellAmount   = req.query.sellAmount;
+
+    const sellsNative = isNative(sellTokenRaw);
+    const buysNative  = isNative(buyTokenRaw);
+    const sellAddr    = normalizeToken(sellTokenRaw, chainId);
+    const buyAddr     = normalizeToken(buyTokenRaw,  chainId);
+
+    console.log('dex/quote params:', { chainId, sellToken: sellAddr, buyToken: buyAddr, sellAmount });
 
     // candidate paths (simple; extend as needed)
     const candidates = [
-      { routerPath: [sellAddr, buyAddr], displayPath: [sellsNative ? '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' : sellToken, buysNative ? '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' : buyToken] },
-      { routerPath: [sellAddr, WBNB, buyAddr], displayPath: [sellsNative ? '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' : sellToken, WBNB, buysNative ? '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' : buyToken] }
+      { routerPath: [sellAddr, buyAddr], displayPath: [sellsNative ? NATIVE_SENTINEL : sellTokenRaw, buysNative ? NATIVE_SENTINEL : buyTokenRaw] },
+      { routerPath: [sellAddr, WBNB, buyAddr], displayPath: [sellsNative ? NATIVE_SENTINEL : sellTokenRaw, WBNB, buysNative ? NATIVE_SENTINEL : buyTokenRaw] }
     ].filter(c => c.routerPath.every(Boolean) && new Set(c.routerPath).size === c.routerPath.length);
 
     const routers = [
-      { name: "Pancake", addr: PANCAKE.ROUTER },
-      { name: "ApeSwap", addr: APESWAP.ROUTER }
+      { name: 'Pancake', addr: PANCAKE.ROUTER },
+      { name: 'ApeSwap', addr: APESWAP.ROUTER }
     ];
 
     let best = null;
@@ -54,7 +77,7 @@ router.get('/quote', async (req, res) => {
       }
     }
 
-    if (!best) return res.status(404).json({ error: "No route on Pancake/ApeSwap" });
+    if (!best) return res.status(404).json({ error: 'No route on Pancake/ApeSwap' });
     res.json(best);
   } catch (e) {
     res.status(500).json({ error: e.message });
@@ -62,3 +85,4 @@ router.get('/quote', async (req, res) => {
 });
 
 module.exports = router;
+


### PR DESCRIPTION
## Summary
- Normalize native BNB tokens to WBNB on BSC for 0x price/quote endpoints
- Apply same normalization for DEX quote endpoint
- Log normalized params for easier debugging

## Testing
- `npm test --prefix gcc-safeswap/packages/backend` *(fails: Missing script: "test")*
- `pytest` *(fails: 7 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8cdb5098832ba503d9bec7a87717