### PR TITLE
Fix MetaMask wiring and add mobile deep links

### DIFF
--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -30,16 +30,14 @@ export default function App() {
         if (acc?.[0]) setAccount(acc[0]);
       } catch {}
     })();
+
+    if (!window.ethereum) return;
     const onAccountsChanged = a => setAccount(a?.[0] || '');
-    if (window.ethereum?.on) {
-      window.ethereum.on('accountsChanged', onAccountsChanged);
-      window.ethereum.on('chainChanged', refreshShield);
-    }
+    window.ethereum.on('accountsChanged', onAccountsChanged);
+    window.ethereum.on('chainChanged', refreshShield);
     return () => {
-      if (window.ethereum?.removeListener) {
-        window.ethereum.removeListener('accountsChanged', onAccountsChanged);
-        window.ethereum.removeListener('chainChanged', refreshShield);
-      }
+      window.ethereum.removeListener('accountsChanged', onAccountsChanged);
+      window.ethereum.removeListener('chainChanged', refreshShield);
     };
   }, [refreshShield]);
 

--- a/gcc-safeswap/packages/frontend/src/lib/deeplink.js
+++ b/gcc-safeswap/packages/frontend/src/lib/deeplink.js
@@ -1,7 +1,0 @@
-export function isMobile() {
-  return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-}
-export function metamaskDappLink() {
-  const host = window.location.host; // e.g. localhost:5173 or prod domain
-  return `https://metamask.app.link/dapp/${host}`;
-}

--- a/gcc-safeswap/packages/frontend/src/lib/metamask.js
+++ b/gcc-safeswap/packages/frontend/src/lib/metamask.js
@@ -1,0 +1,21 @@
+export function isMobile() {
+  return /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+}
+
+export function dappDeepLink(origin) {
+  // Must be a public/lan host, not localhost for mobile
+  const host = origin.replace(/^https?:\/\//, "");
+  return `https://metamask.app.link/dapp/${host}`;
+}
+
+// BNB Private RPC add network deep link (MetaMask supports these params)
+export function addNetworkDeepLink() {
+  const params = new URLSearchParams({
+    chainId: "56",
+    chainName: "BNB Smart Chain (MEV Guard)",
+    rpcUrl: "https://bscrpc.pancakeswap.finance",
+    blockExplorerUrl: "https://bscscan.com",
+    symbol: "BNB"
+  });
+  return `https://metamask.app.link/add-network?${params.toString()}`;
+}

--- a/gcc-safeswap/packages/frontend/vite.config.js
+++ b/gcc-safeswap/packages/frontend/vite.config.js
@@ -4,8 +4,10 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
+    port: 5173,
+    host: true,
     proxy: {
-      '/api': 'http://localhost:8787'
+      '/api': { target: 'http://localhost:8787', changeOrigin: true }
     }
   }
 });


### PR DESCRIPTION
## Summary
- Handle account and chain events via `window.ethereum`
- Add deep links and network helpers for MetaMask Mobile
- Expose Vite dev server to LAN

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm run build` *(fails: vite: not found)*
- `pytest` *(fails: iterator should return strings, not bytes; TypeError: can't subtract offset-naive and offset-aware datetimes)*

------
https://chatgpt.com/codex/tasks/task_e_68bfafa921bc832b892e1530d134e3d7