### PR TITLE
Harden quote fetches and tweak landing copy

### DIFF
--- a/gcc-safeswap/packages/backend/routes/dex.js
+++ b/gcc-safeswap/packages/backend/routes/dex.js
@@ -35,7 +35,7 @@ function toHex(v){ return ethers.toBeHex(v); }
 router.get('/quote', async (req, res) => {
   try {
     const chainId = Number(req.query.chainId || CHAIN_BSC);
-    if (chainId !== CHAIN_BSC) return res.status(400).json({ error: 'Only BNB Chain (56) supported' });
+    if (chainId !== CHAIN_BSC) return res.status(400).json({ ok: false, status: 400, error: 'Only BNB Chain (56) supported' });
 
     const rpc = process.env.PRIVATE_RPC_URL;
     const provider = new ethers.JsonRpcProvider(rpc, 56);
@@ -77,10 +77,10 @@ router.get('/quote', async (req, res) => {
       }
     }
 
-    if (!best) return res.status(404).json({ error: 'No route on Pancake/ApeSwap' });
+    if (!best) return res.status(404).json({ ok: false, status: 404, error: 'No route on Pancake/ApeSwap' });
     res.json(best);
   } catch (e) {
-    res.status(500).json({ error: e.message });
+    res.status(500).json({ ok: false, status: 500, error: e.message });
   }
 });
 

--- a/gcc-safeswap/packages/backend/routes/util.js
+++ b/gcc-safeswap/packages/backend/routes/util.js
@@ -1,0 +1,21 @@
+const fetch = require('node-fetch');
+
+async function safeProxyJson(req, res, url, headers = {}) {
+  try {
+    const r = await fetch(url, { headers });
+    const ct = r.headers.get('content-type') || '';
+    let body;
+    if (ct.includes('application/json')) {
+      body = await r.json().catch(() => ({}));
+    } else {
+      const text = await r.text();
+      body = { error: 'non-json-response', text };
+    }
+    if (!r.ok) return res.status(r.status).json({ ok: false, status: r.status, ...body });
+    return res.json(body);
+  } catch (e) {
+    return res.status(502).json({ ok: false, status: 502, error: e.message });
+  }
+}
+
+module.exports = { safeProxyJson };

--- a/gcc-safeswap/packages/backend/routes/zeroex.js
+++ b/gcc-safeswap/packages/backend/routes/zeroex.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const fetch = require("node-fetch");
+const { safeProxyJson } = require("./util.js");
 
 const router = express.Router();
 const BASE = "https://api.0x.org";
@@ -32,45 +32,31 @@ function buildUrl(base, queryObj) {
 }
 
 // ----- Indicative price -----
-router.get("/price", async (req, res) => {
-  try {
-    const q = { ...req.query };
-    q.chainId = q.chainId || CHAIN_BSC;
+router.get("/price", (req, res) => {
+  const q = { ...req.query };
+  q.chainId = q.chainId || CHAIN_BSC;
 
-    // normalize native BNB ➜ WBNB
-    q.sellToken = normalizeToken(q.sellToken, q.chainId);
-    q.buyToken  = normalizeToken(q.buyToken,  q.chainId);
+  // normalize native BNB ➜ WBNB
+  q.sellToken = normalizeToken(q.sellToken, q.chainId);
+  q.buyToken  = normalizeToken(q.buyToken,  q.chainId);
 
-    const url = buildUrl(`${BASE}/swap/v2/price`, q);
-    const r = await fetch(url, { headers: authHeaders() });
-    const j = await r.json().catch(() => ({}));
-    if (!r.ok) return res.status(r.status).json(j);
-    res.json(j);
-  } catch (e) {
-    res.status(500).json({ error: e.message });
-  }
+  const url = buildUrl(`${BASE}/swap/v2/price`, q);
+  return safeProxyJson(req, res, url, authHeaders());
 });
 
 // ----- Firm quote w/ calldata -----
-router.get("/quote", async (req, res) => {
-  try {
-    const q = { ...req.query };
-    q.chainId = q.chainId || CHAIN_BSC;
+router.get("/quote", (req, res) => {
+  const q = { ...req.query };
+  q.chainId = q.chainId || CHAIN_BSC;
 
-    // normalize native BNB ➜ WBNB
-    q.sellToken = normalizeToken(q.sellToken, q.chainId);
-    q.buyToken  = normalizeToken(q.buyToken,  q.chainId);
+  // normalize native BNB ➜ WBNB
+  q.sellToken = normalizeToken(q.sellToken, q.chainId);
+  q.buyToken  = normalizeToken(q.buyToken,  q.chainId);
 
-    console.log("0x/quote params:", q);
+  console.log("0x/quote params:", q);
 
-    const url = buildUrl(`${BASE}/swap/v2/quote`, q);
-    const r = await fetch(url, { headers: authHeaders() });
-    const j = await r.json().catch(() => ({}));
-    if (!r.ok) return res.status(r.status).json(j);
-    res.json(j);
-  } catch (e) {
-    res.status(500).json({ error: e.message });
-  }
+  const url = buildUrl(`${BASE}/swap/v2/quote`, q);
+  return safeProxyJson(req, res, url, authHeaders());
 });
 
 module.exports = router;

--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -98,7 +98,7 @@ export default function App() {
       <section className="hero container">
         <div className="hero__copy">
           <h1><span className="glow">SafeSwap</span> for Condorians</h1>
-          <p className="lead">Private, MEV-protected swaps with Apple-style simplicity.</p>
+          <p className="lead">Private, MEV-protected swaps.</p>
           <div className="cta">
             <button className="btn btn--primary" onClick={scrollToSwap}>Start Swapping</button>
           </div>

--- a/gcc-safeswap/packages/frontend/src/components/SafeSwap.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/SafeSwap.jsx
@@ -80,9 +80,10 @@ export default function SafeSwap({ account, serverSigner }) {
         ]);
       } catch (e) {
         const [r0, r1] = await Promise.allSettled([p0x, pDex]);
-        const err = (r0.value && !r0.value.ok && r0.value.json?.message) ||
-                    (r1.value && !r1.value.ok && r1.value.json?.error) ||
-                    'No route';
+        const err =
+          (r0.value && !r0.value.ok && (r0.value.json?.validationErrors?.[0]?.reason || r0.value.json?.error || r0.value.json?.message || `HTTP ${r0.value.status}`)) ||
+          (r1.value && !r1.value.ok && (r1.value.json?.error || `HTTP ${r1.value.status}`)) ||
+          'No route';
         setQuote(null);
         setStatus(`Quote error: ${err}`);
         log(`QUOTE fail: ${err}`);

--- a/gcc-safeswap/packages/frontend/src/lib/net.js
+++ b/gcc-safeswap/packages/frontend/src/lib/net.js
@@ -3,7 +3,14 @@ export async function fetchJSON(url, { timeoutMs = 7000, ...opts } = {}) {
   const t = setTimeout(() => ctrl.abort('timeout'), timeoutMs);
   try {
     const res = await fetch(url, { ...opts, signal: ctrl.signal });
-    const json = await res.json().catch(() => ({}));
+    const ct = res.headers.get('content-type') || '';
+    let json;
+    if (ct.includes('application/json')) {
+      json = await res.json().catch(() => ({}));
+    } else {
+      const text = await res.text();
+      json = { error: 'non-json-response', text };
+    }
     return { ok: res.ok, status: res.status, json };
   } finally {
     clearTimeout(t);


### PR DESCRIPTION
## Summary
- add safeProxyJson wrapper to ensure backend quote routes always return JSON
- guard frontend fetch helpers and quote handler against non‑JSON responses
- update landing page hero text to “Private, MEV-protected swaps.”

## Testing
- `npm test` *(backend: missing script)*
- `npm test` *(frontend: missing script)*
- `pytest` *(fail: CSV parsing and price service issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb94ce430832ba2ebd6fc8ecccb65