### PR TITLE
Enable 0x key and MetaMask-ready swap

### DIFF
--- a/gcc-safeswap/packages/backend/server.cjs
+++ b/gcc-safeswap/packages/backend/server.cjs
@@ -20,7 +20,9 @@ function reqLog(req, res, next) {
   const t0 = Date.now();
   res.on("finish", () => {
     const ms = Date.now() - t0;
-    console.log(`[${new Date().toISOString()}] ${req.method} ${req.originalUrl} -> ${res.statusCode} ${ms}ms`);
+    const body = req.body && Object.keys(req.body).length ? JSON.stringify(req.body).slice(0,200) : '';
+    const bodyPart = body ? ` body=${body}` : '';
+    console.log(`${req.method} ${req.path} -> ${res.statusCode} ${ms}ms${bodyPart}`);
   });
   next();
 }


### PR DESCRIPTION
## Summary
- pass optional 0x API key through backend proxy and guard against non-JSON responses
- add /api/dex/buildTx that builds a MetaMask transaction via 0x or AMM fallback
- streamline logs and wire frontend quote/swap to new buildTx flow

## Testing
- `npm --prefix packages/backend test` *(fails: Missing script "test")*
- `npm --prefix packages/frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbf218b4c832b9e7715dae751b8dc