### PR TITLE
feat(frontend): add portfolio chip

### DIFF
--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import Connect from './components/Connect.jsx';
+import Portfolio from "./components/Portfolio.jsx";
 import SafeSwap from './components/SafeSwap.jsx';
 import WalletUnlockModal from './components/WalletUnlockModal.jsx';
 import useShieldStatus from './hooks/useShieldStatus.js';
@@ -89,10 +89,10 @@ export default function App() {
                   {perfMode ? "Performance Mode: ON" : "Performance Mode: OFF"}
                 </button>
               )}
+            <Portfolio account={activeAccount} />
             <button className="btn" aria-label="Settings" onClick={() => setSettingsOpen(true)}>
               ⚙️ Settings
             </button>
-            <Connect />
           </div>
         </div>
       </header>

--- a/gcc-safeswap/packages/frontend/src/components/Portfolio.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/Portfolio.jsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { formatUnits, ZeroAddress } from "ethers";
+import { getBrowserProvider } from "../lib/ethers.js";
+
+// GCC token (BSC)
+const GCC = "0x092aC429b9c3450c9909433eB0662c3b7c13cF9A";
+// Minimal ERC20 ABI for balanceOf/decimals
+const ERC20_ABI = [
+  "function balanceOf(address) view returns (uint256)",
+  "function decimals() view returns (uint8)",
+  "function symbol() view returns (string)"
+];
+
+export default function Portfolio({ account }) {
+  const [bnb, setBnb] = useState(null);
+  const [gcc, setGcc] = useState(null);
+  const [gccUsd, setGccUsd] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const short = useMemo(() => {
+    if (!account) return "";
+    return `${account.slice(0, 6)}…${account.slice(-4)}`;
+  }, [account]);
+
+  useEffect(() => {
+    if (!account) {
+      setBnb(null); setGcc(null); setGccUsd(null);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const provider = getBrowserProvider();
+
+        // 1) Native BNB balance
+        const bal = await provider.getBalance(account);
+        if (!cancelled) setBnb(Number(formatUnits(bal, 18)));
+
+        // 2) GCC balance
+        const gccCtr = new (await import("ethers")).Contract(GCC, ERC20_ABI, provider);
+        const [raw, dec] = await Promise.all([
+          gccCtr.balanceOf(account),
+          gccCtr.decimals()
+        ]);
+        const gccBal = Number(formatUnits(raw, dec));
+        if (!cancelled) setGcc(gccBal);
+
+        // 3) GCC USD price from backend (DexScreener bridge)
+        const res = await fetch("/api/price/gcc"); // returns { symbol, usd }
+        if (res.ok) {
+          const data = await res.json();
+          if (!cancelled) setGccUsd(typeof data.usd === "number" ? data.usd : null);
+        } else {
+          if (!cancelled) setGccUsd(null);
+        }
+      } catch {
+        if (!cancelled) { setGccUsd(null); }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    // refresh every 30s while mounted
+    const id = setInterval(() => {
+      if (account) {
+        // trigger re-run
+        setBnb((x) => x);
+      }
+    }, 30000);
+
+    return () => { cancelled = true; clearInterval(id); };
+  }, [account]);
+
+  const gccUsdTotal = useMemo(() => {
+    if (gcc == null || gccUsd == null) return null;
+    return gcc * gccUsd;
+  }, [gcc, gccUsd]);
+
+  const onConnect = async () => {
+    if (account) return;
+    try {
+      await getBrowserProvider().send("eth_requestAccounts", []);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <div className="portfolio">
+      <button className="pill pill--address" title={account || ""} onClick={onConnect}>
+        {account ? short : "Connect"}
+      </button>
+
+      <div className="pill pill--metric">
+        <span>BNB</span>
+        <strong>{bnb == null ? "…" : bnb.toFixed(4)}</strong>
+      </div>
+
+      <div className="pill pill--metric">
+        <span>GCC</span>
+        <strong>
+          {gcc == null ? "…" : gcc.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+        </strong>
+      </div>
+
+      <div className="pill pill--metric pill--usd" title="GCC ≈ USD">
+        <span>≈ USD</span>
+        <strong>
+          {gccUsdTotal == null
+            ? "…" 
+            : gccUsdTotal.toLocaleString(undefined, { style: "currency", currency: "USD" })}
+        </strong>
+      </div>
+
+      {loading && <span className="portfolio__spinner" aria-hidden />}
+    </div>
+  );
+}
+

--- a/gcc-safeswap/packages/frontend/src/styles.css
+++ b/gcc-safeswap/packages/frontend/src/styles.css
@@ -323,3 +323,22 @@ footer{ margin-top:auto; }
 @media (max-width: 480px) {
   .debug-log { width: 92vw; right: 4vw; left: 4vw; }
 }
+
+/* Portfolio chip group */
+.portfolio{ display:flex; gap:8px; align-items:center; }
+.pill{ display:inline-flex; align-items:center; gap:8px; }
+.pill--address{ color:var(--cyan); border-color:var(--cyan); }
+.pill--metric{ color:var(--ink); border-color:var(--line); }
+.pill--metric strong{ font-variant-numeric: tabular-nums; }
+.pill--usd{ color: var(--orange); border-color: var(--orange); }
+
+.portfolio__spinner{
+  width:12px; height:12px; border-radius:50%;
+  border:2px solid currentColor; border-top-color: transparent;
+  display:inline-block; animation:spin 1s linear infinite;
+}
+
+@media (max-width:600px){
+  .portfolio{ flex-wrap:wrap; }
+  .pill{ padding:6px 10px; font-size:.85rem; }
+}


### PR DESCRIPTION
## Summary
- add responsive Portfolio chip to display BNB and GCC balances with USD estimate
- wire Portfolio into header navigation and remove old Connect display
- append styles for portfolio chips

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: iterator should return strings, not bytes ... etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aae02210832b95db5a0e9b357043