### PR TITLE
Wire frontend to backend and add mobile optimizations

### DIFF
--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import { ServerSigner } from './lib/serverSigner.js';
 import { getBrowserProvider } from './lib/ethers.js';
 import LogTail from "./components/LogTail.jsx";
 import SettingsDrawer from './components/SettingsDrawer.jsx';
+import PerformanceMode from './components/PerformanceMode.jsx';
 
 export default function App() {
   const [perfMode, setPerfMode] = useState(() => localStorage.getItem("perfMode") === "1");
@@ -84,11 +85,7 @@ export default function App() {
             <a href="/swap" className="pill pill--accent">Swap</a>
           </nav>
           <div className="nav__right">
-              {false && (
-                <button className="btn" onClick={togglePerf} aria-pressed={perfMode}>
-                  {perfMode ? "Performance Mode: ON" : "Performance Mode: OFF"}
-                </button>
-              )}
+              {false && <PerformanceMode perfMode={perfMode} toggle={togglePerf} />}
             <Portfolio account={activeAccount} />
             <button className="btn" aria-label="Settings" onClick={() => setSettingsOpen(true)}>
               ⚙️ Settings

--- a/gcc-safeswap/packages/frontend/src/components/Connect.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/Connect.jsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from "react";
 import { getBrowserProvider } from "../lib/ethers.js";
 import useBalances from "../hooks/useBalances.js";
 import TOKENS from "../lib/tokens-bsc.js";
-import { isMobile, addNetworkDeepLink } from "../lib/metamask.js";
-import { openMetaMaskDapp } from "../lib/deeplink.js";
+import { isMobile, addNetworkDeepLink, dappDeepLink } from "../lib/metamask.js";
 import useGccUsd from "../hooks/useGccUsd.js";
 
 export default function Connect({ unlockedAddr }) {
@@ -101,7 +100,7 @@ export default function Connect({ unlockedAddr }) {
           <button onClick={connect}>Connect MetaMask</button>
           {isMobile() && !window.ethereum && (
             <>
-              <button className="btn" onClick={() => openMetaMaskDapp(window.location.origin)}>Open in MetaMask</button>
+              <a className="btn" href={dappDeepLink(window.location.origin)}>Open in MetaMask</a>
               <a className="btn" href={addNetworkDeepLink()}>Add Private RPC</a>
             </>
           )}

--- a/gcc-safeswap/packages/frontend/src/components/LogTail.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/LogTail.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 
 export default function LogTail() {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   const [lines, setLines] = useState([]);
   const boxRef = useRef(null);
 
@@ -42,8 +42,7 @@ export default function LogTail() {
         {open ? 'Hide Logs' : 'Show Logs'}
       </button>
 
-      {open && (
-        <div className="debug-log card">
+      <div className="debug-log card" style={{ display: open ? 'block' : 'none' }}>
           <div className="debug-log__header">
             <span>Debug Log</span>
             <div className="actions">
@@ -55,7 +54,6 @@ export default function LogTail() {
             {lines.join('\n')}
           </pre>
         </div>
-      )}
     </div>
   );
 }

--- a/gcc-safeswap/packages/frontend/src/components/PerformanceMode.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/PerformanceMode.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function PerformanceMode({ perfMode, toggle }) {
+  return (
+    <button className="btn" onClick={toggle} aria-pressed={perfMode}>
+      {perfMode ? "Performance Mode: ON" : "Performance Mode: OFF"}
+    </button>
+  );
+}

--- a/gcc-safeswap/packages/frontend/src/components/Portfolio.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/Portfolio.jsx
@@ -1,21 +1,12 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { formatUnits, ZeroAddress } from "ethers";
+import { formatUnits } from "ethers";
 import { getBrowserProvider } from "../lib/ethers.js";
-
-// GCC token (BSC)
-const GCC = "0x092aC429b9c3450c9909433eB0662c3b7c13cF9A";
-// Minimal ERC20 ABI for balanceOf/decimals
-const ERC20_ABI = [
-  "function balanceOf(address) view returns (uint256)",
-  "function decimals() view returns (uint8)",
-  "function symbol() view returns (string)"
-];
+import useGccUsd from "../hooks/useGccUsd.js";
+import { isMobile, dappDeepLink, addNetworkDeepLink } from "../lib/metamask.js";
 
 export default function Portfolio({ account }) {
   const [bnb, setBnb] = useState(null);
-  const [gcc, setGcc] = useState(null);
-  const [gccUsd, setGccUsd] = useState(null);
-  const [loading, setLoading] = useState(false);
+  const { usd, gcc, loading } = useGccUsd(account);
 
   const short = useMemo(() => {
     if (!account) return "";
@@ -23,68 +14,25 @@ export default function Portfolio({ account }) {
   }, [account]);
 
   useEffect(() => {
-    if (!account) {
-      setBnb(null); setGcc(null); setGccUsd(null);
-      return;
-    }
-
+    if (!account) { setBnb(null); return; }
     let cancelled = false;
     (async () => {
       try {
-        setLoading(true);
         const provider = getBrowserProvider();
-
-        // 1) Native BNB balance
         const bal = await provider.getBalance(account);
         if (!cancelled) setBnb(Number(formatUnits(bal, 18)));
-
-        // 2) GCC balance
-        const gccCtr = new (await import("ethers")).Contract(GCC, ERC20_ABI, provider);
-        const [raw, dec] = await Promise.all([
-          gccCtr.balanceOf(account),
-          gccCtr.decimals()
-        ]);
-        const gccBal = Number(formatUnits(raw, dec));
-        if (!cancelled) setGcc(gccBal);
-
-        // 3) GCC USD price from backend (DexScreener bridge)
-        const res = await fetch("/api/price/gcc"); // returns { symbol, usd }
-        if (res.ok) {
-          const data = await res.json();
-          if (!cancelled) setGccUsd(typeof data.usd === "number" ? data.usd : null);
-        } else {
-          if (!cancelled) setGccUsd(null);
-        }
       } catch {
-        if (!cancelled) { setGccUsd(null); }
-      } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setBnb(null);
       }
     })();
-
-    // refresh every 30s while mounted
-    const id = setInterval(() => {
-      if (account) {
-        // trigger re-run
-        setBnb((x) => x);
-      }
-    }, 30000);
-
-    return () => { cancelled = true; clearInterval(id); };
+    return () => { cancelled = true; };
   }, [account]);
-
-  const gccUsdTotal = useMemo(() => {
-    if (gcc == null || gccUsd == null) return null;
-    return gcc * gccUsd;
-  }, [gcc, gccUsd]);
 
   const onConnect = async () => {
     if (account) return;
     try {
       await getBrowserProvider().send("eth_requestAccounts", []);
-    } catch {
-      /* ignore */
-    }
+    } catch {}
   };
 
   return (
@@ -92,30 +40,23 @@ export default function Portfolio({ account }) {
       <button className="pill pill--address" title={account || ""} onClick={onConnect}>
         {account ? short : "Connect"}
       </button>
-
       <div className="pill pill--metric">
         <span>BNB</span>
         <strong>{bnb == null ? "…" : bnb.toFixed(4)}</strong>
       </div>
-
       <div className="pill pill--metric">
         <span>GCC</span>
-        <strong>
-          {gcc == null ? "…" : gcc.toLocaleString(undefined, { maximumFractionDigits: 2 })}
-        </strong>
+        <strong>{gcc == null ? "…" : gcc.toLocaleString(undefined, { maximumFractionDigits: 2 })}</strong>
       </div>
-
-      <div className="pill pill--metric pill--usd" title="GCC ≈ USD">
-        <span>≈ USD</span>
-        <strong>
-          {gccUsdTotal == null
-            ? "…" 
-            : gccUsdTotal.toLocaleString(undefined, { style: "currency", currency: "USD" })}
-        </strong>
-      </div>
-
-      {loading && <span className="portfolio__spinner" aria-hidden />}
+      <button className="pill">
+        ▸ Portfolio {loading ? '' : (usd != null ? `• $${usd.toFixed(2)}` : '')}
+      </button>
+      {isMobile() && !window.ethereum && (
+        <div className="actions">
+          <a className="btn" href={dappDeepLink(window.location.origin)}>Open in MetaMask</a>
+          <a className="btn" href={addNetworkDeepLink()}>Add BNB (Private)</a>
+        </div>
+      )}
     </div>
   );
 }
-

--- a/gcc-safeswap/packages/frontend/src/components/WalletDrawer.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/WalletDrawer.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import DropZone from './DropZone.jsx';
 import Fingerprint from './Fingerprint.jsx';
+import { API_BASE } from '../lib/apiBase.js';
 
 export default function WalletDrawer({ open, onClose }) {
   const [wallet, setWallet] = useState(null);
@@ -18,7 +19,7 @@ export default function WalletDrawer({ open, onClose }) {
 
   const generate = async () => {
     setMessage('');
-    const resp = await fetch('/api/wallet/generate', { method: 'POST' });
+    const resp = await fetch(`${API_BASE}/api/wallet/generate`, { method: 'POST' });
     const data = await resp.json();
     if (resp.ok) setWallet(data);
     else setMessage(data.error || 'error');
@@ -33,7 +34,7 @@ export default function WalletDrawer({ open, onClose }) {
     form.append('handle', wallet.handle);
     form.append('passphrase', pass);
     form.append('image', file);
-    const resp = await fetch('/api/wallet/embed', { method: 'POST', body: form });
+    const resp = await fetch(`${API_BASE}/api/wallet/embed`, { method: 'POST', body: form });
     if (!resp.ok) {
       const err = await resp.json();
       setMessage(err.error || 'error');
@@ -57,7 +58,7 @@ export default function WalletDrawer({ open, onClose }) {
     const form = new FormData();
     form.append('passphrase', dpass);
     form.append('image', dfile);
-    const resp = await fetch('/api/wallet/decode', { method: 'POST', body: form });
+    const resp = await fetch(`${API_BASE}/api/wallet/decode`, { method: 'POST', body: form });
     const data = await resp.json();
     if (resp.ok) { setDecode(data); setDmsg(''); }
     else setDmsg(data.error || 'error');

--- a/gcc-safeswap/packages/frontend/src/components/WalletUnlockModal.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/WalletUnlockModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import DropZone from './DropZone.jsx';
 import Fingerprint from './Fingerprint.jsx';
+import { API_BASE } from '../lib/apiBase.js';
 
 export default function WalletUnlockModal({ open, onClose, onUnlocked, onUseForSigning, onDestroy }) {
   const [file, setFile] = useState(null);
@@ -20,7 +21,7 @@ export default function WalletUnlockModal({ open, onClose, onUnlocked, onUseForS
     const form = new FormData();
     form.append('image', file);
     form.append('passphrase', pass);
-    const resp = await fetch('/api/wallet/unlock', { method: 'POST', body: form });
+    const resp = await fetch(`${API_BASE}/api/wallet/unlock`, { method: 'POST', body: form });
     const data = await resp.json();
     if (!resp.ok || data.error) {
       setMsg(data.error || 'error');
@@ -38,7 +39,7 @@ export default function WalletUnlockModal({ open, onClose, onUnlocked, onUseForS
 
   const destroy = async () => {
     if (wallet) {
-      await fetch('/api/wallet/destroy', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ sessionId: wallet.sessionId }) });
+      await fetch(`${API_BASE}/api/wallet/destroy`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ sessionId: wallet.sessionId }) });
     }
     setWallet(null);
     setFile(null);

--- a/gcc-safeswap/packages/frontend/src/hooks/useAllowance.js
+++ b/gcc-safeswap/packages/frontend/src/hooks/useAllowance.js
@@ -1,5 +1,6 @@
 import { BrowserProvider, Contract, ethers, Interface } from "ethers";
 import { getRpcProvider } from "../lib/ethers";
+import { API_BASE } from "../lib/apiBase.js";
 
 export default function useAllowance() {
   async function ensure({ tokenAddr, owner, spender, amount, approveMax, serverSigner }) {
@@ -14,7 +15,7 @@ export default function useAllowance() {
       const data = iface.encodeFunctionData("approve", [spender, value]);
       const tx = { to: tokenAddr, data, value: 0, chainId: 56 };
       const rawTx = await serverSigner.signTransaction(tx);
-      const resp = await fetch('/api/relay/sendRaw', { method: 'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ rawTx }) });
+      const resp = await fetch(`${API_BASE}/api/relay/sendRaw`, { method: 'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ rawTx }) });
       const j = await resp.json();
       if (!resp.ok || j.error) throw new Error(j.error || 'relay failed');
       return true;

--- a/gcc-safeswap/packages/frontend/src/hooks/useGccUsd.js
+++ b/gcc-safeswap/packages/frontend/src/hooks/useGccUsd.js
@@ -1,29 +1,27 @@
 import { useEffect, useState } from 'react';
 import { getBrowserProvider, erc20 } from '../lib/ethers.js';
+import { API_BASE } from '../lib/apiBase.js';
 
 const GCC = '0x092aC429b9c3450c9909433eB0662c3b7c13cF9A';
 const GCC_DECIMALS = Number(import.meta.env.VITE_GCC_DECIMALS || 9);
 
 export default function useGccUsd(account){
-  const [state, setState] = useState({ usd: null, gcc: null, price: null, loading: true, source: null });
+  const [state, setState] = useState({ usd:null, gcc:null, price:null, loading:true, source:null });
 
   useEffect(() => {
     let off = false;
     (async () => {
       try {
-        setState(s => ({...s, loading:true}));
-        const priceResp = await fetch('/api/price/gcc').then(r=>r.json());
+        const priceResp = await fetch(`${API_BASE}/api/price/gcc`).then(r=>r.json());
         const price = Number(priceResp?.priceUsd || 0);
-
-        let gccBal = null;
+        let gccBal = 0;
         if (account) {
           const prov = getBrowserProvider();
           const c = erc20(GCC, prov);
           const raw = await c.balanceOf(account);
           gccBal = Number(raw) / 10 ** GCC_DECIMALS;
         }
-
-        if (!off) setState({ usd: price * (gccBal||0), gcc: gccBal, price, loading:false, source: priceResp?.source });
+        if (!off) setState({ usd: price * gccBal, gcc: gccBal, price, loading:false, source: priceResp?.source });
       } catch {
         if (!off) setState(s => ({...s, loading:false}));
       }

--- a/gcc-safeswap/packages/frontend/src/hooks/useQuote.js
+++ b/gcc-safeswap/packages/frontend/src/hooks/useQuote.js
@@ -1,4 +1,5 @@
 import { toBase } from "../lib/format.js";
+import { API_BASE } from "../lib/apiBase.js";
 
 export default function useQuote({ chainId=56 }) {
   async function fetch0x({ fromToken, toToken, amountBase, taker, slippageBps }) {
@@ -6,7 +7,7 @@ export default function useQuote({ chainId=56 }) {
       chainId:String(chainId), sellToken:fromToken.address, buyToken:toToken.address,
       sellAmount:amountBase, taker, slippageBps:String(slippageBps)
     });
-    const r = await fetch(`/api/0x/quote?${qs}`); const j = await r.json();
+    const r = await fetch(`${API_BASE}/api/0x/quote?${qs}`); const j = await r.json();
     if (j.code || j.error) throw new Error(j.validationErrors?.[0]?.reason || j.error || "0x quote failed");
     const sources = (j.route?.fills?.map(f=>f.source).join(" → ")) || "mixed";
     return { buyAmount:j.buyAmount, tx:{to:j.to, data:j.data, value:j.value}, routeText:sources, lpLabel:null, impact:false, allowanceTarget:j.allowanceTarget };
@@ -14,9 +15,9 @@ export default function useQuote({ chainId=56 }) {
 
   async function fetchApe({ fromToken, toToken, amountBase }) {
     const rp = new URLSearchParams({ sellToken: fromToken.address, buyToken: toToken.address });
-    const route = await (await fetch(`/api/apeswap/route?${rp}`)).json();
+    const route = await (await fetch(`${API_BASE}/api/apeswap/route?${rp}`)).json();
     const qp = new URLSearchParams({ sellToken: fromToken.address, buyToken: toToken.address, amountIn: amountBase });
-    const out = await (await fetch(`/api/apeswap/amountsOut?${qp}`)).json();
+    const out = await (await fetch(`${API_BASE}/api/apeswap/amountsOut?${qp}`)).json();
     if (out.error) throw new Error(out.error);
     const path = route.path || out.path || [fromToken.address, toToken.address];
     const sym = (a)=>a.toLowerCase();

--- a/gcc-safeswap/packages/frontend/src/lib/apiBase.js
+++ b/gcc-safeswap/packages/frontend/src/lib/apiBase.js
@@ -1,0 +1,3 @@
+export const API_BASE =
+  import.meta.env.VITE_API_BASE ||
+  (typeof window !== 'undefined' ? window.location.origin : '');

--- a/gcc-safeswap/packages/frontend/src/lib/metamask.js
+++ b/gcc-safeswap/packages/frontend/src/lib/metamask.js
@@ -1,21 +1,17 @@
-export function isMobile() {
-  return /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-}
+export const isMobile = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
 export function dappDeepLink(origin) {
-  // Must be a public/lan host, not localhost for mobile
-  const host = origin.replace(/^https?:\/\//, "");
+  const host = origin.replace(/^https?:\/\//,'');
   return `https://metamask.app.link/dapp/${host}`;
 }
 
-// BNB Private RPC add network deep link (MetaMask supports these params)
 export function addNetworkDeepLink() {
-  const params = new URLSearchParams({
+  const p = new URLSearchParams({
     chainId: "56",
     chainName: "BNB Smart Chain (MEV Guard)",
     rpcUrl: "https://bscrpc.pancakeswap.finance",
     blockExplorerUrl: "https://bscscan.com",
     symbol: "BNB"
   });
-  return `https://metamask.app.link/add-network?${params.toString()}`;
+  return `https://metamask.app.link/add-network?${p.toString()}`;
 }

--- a/gcc-safeswap/packages/frontend/src/lib/serverSigner.js
+++ b/gcc-safeswap/packages/frontend/src/lib/serverSigner.js
@@ -1,3 +1,5 @@
+import { API_BASE } from './apiBase.js';
+
 export class ServerSigner {
   constructor(sessionId, address) {
     this.sessionId = sessionId;
@@ -9,7 +11,7 @@ export class ServerSigner {
   }
 
   async signTransaction(tx) {
-    const resp = await fetch('/api/wallet/signTransaction', {
+    const resp = await fetch(`${API_BASE}/api/wallet/signTransaction`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ sessionId: this.sessionId, tx })
@@ -20,7 +22,7 @@ export class ServerSigner {
   }
 
   async signTypedData(domain, types, message) {
-    const resp = await fetch('/api/wallet/signTypedData', {
+    const resp = await fetch(`${API_BASE}/api/wallet/signTypedData`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ sessionId: this.sessionId, domain, types, message })

--- a/gcc-safeswap/packages/frontend/src/plugins/condorWallet/index.js
+++ b/gcc-safeswap/packages/frontend/src/plugins/condorWallet/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { API_BASE } from '../../lib/apiBase.js';
 
 export default function CondorWalletPane() {
   const [file, setFile] = useState(null);
@@ -10,7 +11,7 @@ export default function CondorWalletPane() {
     fd.append('image', file);
     setMsg('Uploading…');
     try {
-      const r = await fetch('/api/plugins/condor-wallet/upload', {
+      const r = await fetch(`${API_BASE}/api/plugins/condor-wallet/upload`, {
         method: 'POST',
         body: fd,
       });
@@ -41,4 +42,3 @@ export default function CondorWalletPane() {
     </div>
   );
 }
-

--- a/gcc-safeswap/packages/frontend/src/plugins/usePlugins.js
+++ b/gcc-safeswap/packages/frontend/src/plugins/usePlugins.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { PLUGIN_META } from './meta.js';
+import { API_BASE } from '../lib/apiBase.js';
 
 // Fetch the backend plugin health endpoint and merge with static metadata
 export default function usePlugins() {
@@ -9,7 +10,7 @@ export default function usePlugins() {
     let alive = true;
     (async () => {
       try {
-        const r = await fetch('/api/plugins/_health');
+        const r = await fetch(`${API_BASE}/api/plugins/_health`);
         const j = await r.json();
         if (!alive) return;
         const items = (j.plugins || []).map((p) => ({
@@ -34,4 +35,3 @@ export default function usePlugins() {
   // Returns array of {name, title, description, icon, loader}
   return plugins;
 }
-

--- a/gcc-safeswap/packages/frontend/src/styles.css
+++ b/gcc-safeswap/packages/frontend/src/styles.css
@@ -342,3 +342,10 @@ footer{ margin-top:auto; }
   .portfolio{ flex-wrap:wrap; }
   .pill{ padding:6px 10px; font-size:.85rem; }
 }
+@media (max-width: 480px){
+  .actions button, .btn, .btn--primary { width:100%; }
+  .holo { margin: 16px auto; }
+  .holo .card { padding: 14px; }
+  .debug-log { display: none; }
+  .debug-toggle { display:inline-block; padding:6px 10px; border:1px solid var(--line); border-radius:8px; }
+}

--- a/gcc-safeswap/packages/frontend/vercel.json
+++ b/gcc-safeswap/packages/frontend/vercel.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "index.html", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
+  ],
+  "routes": [{ "src": "/(.*)", "dest": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- Introduce `API_BASE` utility and wire all backend fetches through it
- Add GCC→USD portfolio hook and MetaMask mobile deep links
- Improve mobile styling and include Vercel deployment config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*
- `pytest` *(fails: csv parsing and price service errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ca7bac60832baea2d02fe1587894