### PR TITLE
Vercel: pin root to packages/frontend, set build/output, SPA rewrites

### DIFF
--- a/gcc-safeswap/.vercel/project.json
+++ b/gcc-safeswap/.vercel/project.json
@@ -1,0 +1,11 @@
+{
+  "projectId": "",
+  "orgId": "",
+  "settings": {
+    "framework": "vite",
+    "buildCommand": "yarn build",
+    "outputDirectory": "dist",
+    "installCommand": "yarn install --frozen-lockfile",
+    "rootDirectory": "packages/frontend"
+  }
+}

--- a/gcc-safeswap/packages/frontend/src/lib/apiBase.js
+++ b/gcc-safeswap/packages/frontend/src/lib/apiBase.js
@@ -1,3 +1,1 @@
-export const API_BASE =
-  import.meta.env.VITE_API_BASE ||
-  (typeof window !== 'undefined' ? window.location.origin : '');
+export const API_BASE = import.meta.env.VITE_API_BASE;

--- a/gcc-safeswap/packages/frontend/vercel.json
+++ b/gcc-safeswap/packages/frontend/vercel.json
@@ -1,7 +1,11 @@
 {
-  "version": 2,
-  "builds": [
-    { "src": "index.html", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
-  ],
-  "routes": [{ "src": "/(.*)", "dest": "/index.html" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ]
 }

--- a/gcc-safeswap/packages/frontend/vite.config.js
+++ b/gcc-safeswap/packages/frontend/vite.config.js
@@ -1,13 +1,7 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  server: {
-    port: 5173,
-    host: true,
-    proxy: {
-      '/api': { target: 'http://localhost:8787', changeOrigin: true, secure: false, rewrite: p => p }
-    }
-  }
-});
+  build: { outDir: 'dist' }
+})


### PR DESCRIPTION
## Summary
- Pin Vercel root to `packages/frontend` and configure Vite build output
- Simplify Vite config and expose API base via environment variable
- Add SPA rewrites and cache headers for assets

## Testing
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn install --immutable` *(fails: RequestError: Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ce2d5a6c832b9f633d39ffedf57b