### PR TITLE
feat: refresh GCC balance on network changes

### DIFF
--- a/gcc-safeswap/packages/frontend/src/components/Portfolio.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/Portfolio.jsx
@@ -2,16 +2,24 @@ import React, { useEffect, useMemo, useState } from "react";
 import { formatUnits } from "ethers";
 import { getBrowserProvider } from "../lib/ethers.js";
 import useGccUsd from "../hooks/useGccUsd.js";
+import useGccBalance from "../hooks/useGccBalance.ts";
 import { isMobile, dappDeepLink, addNetworkDeepLink } from "../lib/metamask.js";
+
+const GCC_TOKEN = import.meta.env.VITE_TOKEN_GCC;
 
 export default function Portfolio({ account }) {
   const [bnb, setBnb] = useState(null);
-  const { usd, gcc, loading } = useGccUsd(account);
+  const { usd, loading } = useGccUsd(account);
+  const { balance: gccBal, err: gccErr } = useGccBalance(GCC_TOKEN, account);
 
   const short = useMemo(() => {
     if (!account) return "";
     return `${account.slice(0, 6)}…${account.slice(-4)}`;
   }, [account]);
+
+  useEffect(() => {
+    console.debug("VITE_TOKEN_GCC", GCC_TOKEN);
+  }, []);
 
   useEffect(() => {
     if (!account) { setBnb(null); return; }
@@ -46,8 +54,9 @@ export default function Portfolio({ account }) {
       </div>
       <div className="pill pill--metric">
         <span>GCC</span>
-        <strong>{gcc == null ? "…" : gcc.toLocaleString(undefined, { maximumFractionDigits: 2 })}</strong>
+        <strong>{gccBal != null ? gccBal.toFixed(2) : "—"}</strong>
       </div>
+      {gccErr && <span className="muted" style={{marginLeft:8}}>({gccErr})</span>}
       <button className="pill">
         ▸ Portfolio {loading ? '' : (usd != null ? `• $${usd.toFixed(2)}` : '')}
       </button>

--- a/gcc-safeswap/packages/frontend/src/hooks/useGccBalance.ts
+++ b/gcc-safeswap/packages/frontend/src/hooks/useGccBalance.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { BrowserProvider, Contract, formatUnits } from "ethers";
+
+const ERC20_ABI = [
+  "function balanceOf(address) view returns (uint256)",
+  "function decimals() view returns (uint8)"
+];
+
+export default function useGccBalance(tokenAddress: string | undefined, account?: string | null) {
+  const [balance, setBalance] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<null | string>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setErr(null);
+      if (!account || !tokenAddress) { setBalance(null); return; }
+      try {
+        const hasEth = typeof window !== "undefined" && (window as any).ethereum;
+        if (!hasEth) return;
+
+        const prov = new BrowserProvider((window as any).ethereum);
+        const network = await prov.getNetwork();
+        // Expect BNB Chain (56 / 0x38)
+        if (Number(network.chainId) !== 56) {
+          setErr("Wrong network (switch to BNB Chain).");
+          setBalance(null);
+          return;
+        }
+
+        const erc20 = new Contract(tokenAddress, ERC20_ABI, prov);
+        const [raw, dec] = await Promise.all([erc20.balanceOf(account), erc20.decimals()]);
+        if (!cancelled) setBalance(Number(formatUnits(raw, dec)));
+      } catch (e: any) {
+        if (!cancelled) {
+          console.debug("GCC balance error:", e);
+          setErr(e?.message || "balance error");
+          setBalance(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    setLoading(true);
+    load();
+
+    // re-run when MM fires account/chain changes (Safari-friendly)
+    const eth = (typeof window !== "undefined" && (window as any).ethereum) || null;
+    const onAcc = () => load();
+    const onChain = () => load();
+    if (eth?.on) {
+      eth.on("accountsChanged", onAcc);
+      eth.on("chainChanged", onChain);
+    }
+
+    // gentle polling safety (30s) in case events are dropped
+    const id = setInterval(load, 30000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+      if (eth?.removeListener) {
+        eth.removeListener("accountsChanged", onAcc);
+        eth.removeListener("chainChanged", onChain);
+      }
+    };
+  }, [account, tokenAddress]);
+
+  return { balance, loading, err };
+}


### PR DESCRIPTION
## Summary
- add a dedicated GCC balance hook that refetches on account or chain changes
- wire Portfolio component to the new hook and show network errors

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e06de7bc832b8a44c501cafb1f00