### PR TITLE
fix: configure backend CORS allowed origins

### DIFF
--- a/gcc-safeswap/packages/backend/.env
+++ b/gcc-safeswap/packages/backend/.env
@@ -8,7 +8,7 @@ RPC_URL_PUBLIC=https://bsc-dataseed.binance.org
 MEV_REGISTRY_URL=https://raw.githubusercontent.com/gcc/mev-registry/main/registry.json
 DEXSCREENER_TOKEN_URL=https://api.dexscreener.com/latest/dex/tokens/${GCC_ADDRESS}
 TX_PAUSED=0
-ALLOWED_ORIGINS=https://<your-vercel-app>.vercel.app,http://localhost:5173
+ALLOWED_ORIGINS=https://gcc-me-vprotect.vercel.app,http://localhost:5173
 
 PORT=10000
 NODE_ENV=production

--- a/gcc-safeswap/packages/backend/server.cjs
+++ b/gcc-safeswap/packages/backend/server.cjs
@@ -11,11 +11,11 @@ const app = express();
 app.use(express.json({ limit: '1mb' }));
 app.use(helmetMiddleware());
 app.use(rateLimit({ windowMs: 60_000, max: 60, standardHeaders: true }));
-const ALLOWED = (process.env.ALLOWED_ORIGINS || '')
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
   .split(',').map(s => s.trim()).filter(Boolean);
 app.use(cors({
   origin(origin, cb){
-    if (!origin || ALLOWED.includes(origin)) return cb(null, true);
+    if (!origin || allowedOrigins.includes(origin)) return cb(null, true);
     cb(new Error('CORS: origin not allowed'));
   },
   credentials: true


### PR DESCRIPTION
## Summary
- parse allowed origins from `ALLOWED_ORIGINS` env var and restrict CORS accordingly
- add production and dev URLs to `ALLOWED_ORIGINS`

## Testing
- `pytest` *(fails: iterator should return strings, not bytes, AttributeError: 'list' object has no attribute 'items', TypeError: can't subtract offset-naive and offset-aware datetimes)*
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68c0fcf1ef30832b8b13d887ba0b6afc