### PR TITLE
feat: stabilize CORS for Vercel deployments

### DIFF
--- a/gcc-safeswap/packages/backend/server.cjs
+++ b/gcc-safeswap/packages/backend/server.cjs
@@ -1,25 +1,65 @@
 require('dotenv').config();
 const { env, summarize } = require('./config/env');
 const express = require('express');
+const cors = require('cors');
 let helmetMiddleware = () => (req,res,next)=>next();
 try { helmetMiddleware = require('helmet'); } catch {}
 const rateLimit = require('express-rate-limit');
-const cors = require('cors');
 const { refreshRegistry } = require('./mev/registry');
 
 const app = express();
-app.use(express.json({ limit: '1mb' }));
-app.use(helmetMiddleware());
-app.use(rateLimit({ windowMs: 60_000, max: 60, standardHeaders: true }));
-const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
-  .split(',').map(s => s.trim()).filter(Boolean);
-app.use(cors({
-  origin(origin, cb){
-    if (!origin || allowedOrigins.includes(origin)) return cb(null, true);
+
+// Allow production + preview Vercel + local dev
+const ORIGINS = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+console.log('[env] ALLOWED_ORIGINS:', ORIGINS);
+
+// Regex for Vercel preview branches of THIS project
+const vercelPreviewRe = /^https:\/\/gcc-me-vprotect(-git-[a-z0-9-]+)?\.vercel\.app$/i;
+
+// Decide per-request
+const corsOptions = {
+  origin(origin, cb) {
+    if (!origin) return cb(null, true);
+
+    if (
+      ORIGINS.includes(origin) ||
+      vercelPreviewRe.test(origin) ||
+      origin === 'http://localhost:5173'
+    ) return cb(null, true);
+
     cb(new Error('CORS: origin not allowed'));
   },
-  credentials: true
-}));
+  credentials: false,
+  methods: ['GET', 'POST', 'OPTIONS'],
+  allowedHeaders: [
+    'Content-Type',
+    'Authorization',
+    'x-api-key',
+    'x-requested-with'
+  ],
+  maxAge: 86400
+};
+
+// Must be the FIRST middleware
+app.use(cors(corsOptions));
+
+// Handle explicit preflight quickly
+app.options('*', cors(corsOptions));
+
+// keep caches honest
+app.use((req, res, next) => { res.setHeader('Vary', 'Origin'); next(); });
+
+// body parsers
+app.use(express.json({ limit: '1mb' }));
+
+// security & rate limit
+app.use(helmetMiddleware());
+app.use(rateLimit({ windowMs: 60_000, max: 60, standardHeaders: true }));
+
+// misc headers
 app.use((_,res,next)=>{ res.setHeader('x-robots-tag','noindex'); next(); });
 
 console.log('[env] loaded:', summarize());
@@ -63,6 +103,15 @@ app.get('/health', (_req, res) => {
 // mount routes
 app.use('/api/dex', require('./routes/dex'));
 require('./routes')(app, env);
+
+// error handler
+app.use((err, req, res, next) => {
+  if (err?.message?.startsWith('CORS:')) {
+    return res.status(403).json({ error: err.message });
+  }
+  console.error('Unhandled error:', err);
+  res.status(500).json({ error: 'internal_error' });
+});
 
 app.listen(env.PORT, () => {
   console.log(`Server running on ${env.PORT}`);

--- a/gcc-safeswap/packages/frontend/src/lib/api.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/api.ts
@@ -3,6 +3,25 @@ import { log } from './logger.js';
 const API = import.meta.env.VITE_API_BASE;
 const API_BASE = API?.replace(/\/$/, "");
 
+export async function api(path: string, init: RequestInit = {}) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: init.method || "GET",
+    mode: "cors",
+    credentials: "omit",
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers || {})
+    },
+    body: init.body ? JSON.stringify(init.body) : undefined,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`API ${res.status}: ${text || res.statusText}`);
+  }
+  return res.json();
+}
+
 type Opts = { timeoutMs?: number; signal?: AbortSignal };
 
 export async function apiGet<T>(path: string, opts: Opts = {}): Promise<T> {
@@ -40,7 +59,10 @@ export async function apiGetRetry<T>(path: string, tries = 2): Promise<T> {
 
 export async function oxQuote(params: Record<string,string>) {
   const qs = new URLSearchParams(params);
-  const r = await fetch(`${API}/api/0x/quote?${qs}`);
+  const r = await fetch(`${API}/api/0x/quote?${qs}`, {
+    mode: "cors",
+    credentials: "omit"
+  });
   const text = await r.text();
   log('0x ⇢', r.status, text.slice(0, 300));
   if (!r.ok) throw new Error(`0x ${r.status}: ${text}`);
@@ -49,7 +71,10 @@ export async function oxQuote(params: Record<string,string>) {
 
 export async function dexQuote(params: Record<string,string>) {
   const qs = new URLSearchParams(params);
-  const r = await fetch(`${API}/api/dex/quote?${qs}`);
+  const r = await fetch(`${API}/api/dex/quote?${qs}`, {
+    mode: "cors",
+    credentials: "omit"
+  });
   const text = await r.text();
   log('DEX ⇢', r.status, text.slice(0, 300));
   if (!r.ok) throw new Error(`DEX ${r.status}: ${text}`);


### PR DESCRIPTION
## Summary
- add dynamic CORS middleware to backend with support for Vercel previews and localhost
- expose unified `api` helper and ensure CORS-friendly fetch settings on frontend

## Testing
- `pytest` *(fails: _csv.Error: iterator should return strings, not bytes (the file should be opened in text mode); AttributeError: 'list' object has no attribute 'items'; AssertionError: assert False; TypeError: can't subtract offset-naive and offset-aware datetimes)*
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `curl -i -X OPTIONS -H "Origin: https://gcc-me-vprotect.vercel.app" -H "Access-Control-Request-Method: GET" -H "Access-Control-Request-Headers: content-type,x-api-key" https://gcc-mevprotect.onrender.com/api/price/gcc` *(fail: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1011039bc832b860fe8538f63c319