### PR TITLE
Add PancakeSwap fallback and remove legacy price calls

### DIFF
--- a/gcc-safeswap/packages/backend/package.json
+++ b/gcc-safeswap/packages/backend/package.json
@@ -9,6 +9,7 @@
     "cors": "2.8.5",
     "express": "4.19.2",
     "morgan": "1.10.0",
-    "node-fetch": "2.7.0"
+    "node-fetch": "2.7.0",
+    "ethers": "5.7.2"
   }
 }

--- a/gcc-safeswap/packages/frontend/src/hooks/useGccUsd.js
+++ b/gcc-safeswap/packages/frontend/src/hooks/useGccUsd.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { getBrowserProvider, erc20 } from '../lib/ethers.js';
-import { api } from '../lib/api';
+import { getQuote } from '../lib/api';
 
 const GCC = '0x092aC429b9c3450c9909433eB0662c3b7c13cF9A';
 const GCC_DECIMALS = Number(import.meta.env.VITE_GCC_DECIMALS || 9);
@@ -12,10 +12,12 @@ export default function useGccUsd(account){
     let off = false;
     (async () => {
       try {
-        const r = await fetch(api('price/gcc'));
-        if (!r.ok) throw new Error(`Quote failed: ${r.status}`);
-        const priceResp = await r.json();
-        const price = Number(priceResp?.usd ?? priceResp?.priceUsd ?? priceResp?.price ?? 0);
+        const ONE_GCC = (10n ** BigInt(GCC_DECIMALS)).toString();
+        const [gccBnb, bnbUsd] = await Promise.all([
+          getQuote({ fromToken: 'GCC', toToken: 'BNB', amountWei: ONE_GCC }),
+          getQuote({ fromToken: 'BNB', toToken: 'USDT', amountWei: (10n ** 18n).toString() })
+        ]);
+        const price = (Number(gccBnb.buyAmount) / 1e18) * (Number(bnbUsd.buyAmount) / 1e18);
         let gccBal = 0;
         if (account) {
           const prov = getBrowserProvider();
@@ -23,7 +25,7 @@ export default function useGccUsd(account){
           const raw = await c.balanceOf(account);
           gccBal = Number(raw) / 10 ** GCC_DECIMALS;
         }
-        if (!off) setState({ usd: price * gccBal, gcc: gccBal, price, loading:false, source: priceResp?.source });
+        if (!off) setState({ usd: price * gccBal, gcc: gccBal, price, loading:false, source: gccBnb?.source });
       } catch {
         if (!off) setState(s => ({...s, loading:false}));
       }


### PR DESCRIPTION
## Summary
- remove outdated `/price/gcc` calls and derive GCC price using quote API
- add PancakeSwap v2 router fallback when 0x has no route
- include ethers dependency for on-chain quoting

## Testing
- `npm --prefix gcc-safeswap/packages/backend test` (fails: Missing script "test")
- `npm --prefix gcc-safeswap/packages/frontend test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c11f7837b0832b9f9237d8b410b6b6