### PR TITLE
feat: add pricebook endpoint and portfolio value

### DIFF
--- a/gcc-safeswap/packages/frontend/src/components/Portfolio.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/Portfolio.jsx
@@ -1,16 +1,18 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { formatUnits } from "ethers";
 import { getBrowserProvider } from "../lib/ethers.js";
-import useGccUsd from "../hooks/useGccUsd.js";
 import useGccBalance from "../hooks/useGccBalance.ts";
+import { api } from "../lib/api.js";
+import { logInfo, logError } from "../lib/logger.js";
 import { isMobile, dappDeepLink, addNetworkDeepLink } from "../lib/metamask.js";
 
 const GCC_TOKEN = import.meta.env.VITE_TOKEN_GCC;
 
 export default function Portfolio({ account }) {
   const [bnb, setBnb] = useState(null);
-  const { usd, loading } = useGccUsd(account);
-  const { balance: gccBal, err: gccErr } = useGccBalance(GCC_TOKEN, account);
+  const [bnbWei, setBnbWei] = useState(0n);
+  const [usd, setPortfolioUSD] = useState(null);
+  const { balance: gccBal, raw: gccWei, err: gccErr } = useGccBalance(GCC_TOKEN, account);
 
   const short = useMemo(() => {
     if (!account) return "";
@@ -22,19 +24,50 @@ export default function Portfolio({ account }) {
   }, []);
 
   useEffect(() => {
-    if (!account) { setBnb(null); return; }
+    if (!account) { setBnb(null); setBnbWei(0n); return; }
     let cancelled = false;
     (async () => {
       try {
         const provider = getBrowserProvider();
         const bal = await provider.getBalance(account);
-        if (!cancelled) setBnb(Number(formatUnits(bal, 18)));
+        if (!cancelled) {
+          setBnb(Number(formatUnits(bal, 18)));
+          setBnbWei(bal);
+        }
       } catch {
         if (!cancelled) setBnb(null);
       }
     })();
     return () => { cancelled = true; };
   }, [account]);
+
+  async function refreshPortfolioValue() {
+    try {
+      const url = api("/api/pricebook");
+      const pb = await fetch(url).then(r => r.json());
+
+      const bnbUsd = BigInt(pb.wbnbUsd);
+      const gccUsd = BigInt(pb.gccUsd);
+
+      const gccUsdValue = (BigInt(gccWei || 0n) * gccUsd) / 10n**18n;
+      const bnbUsdValue = (bnbWei * bnbUsd) / 10n**18n;
+      const totalUsdWei = gccUsdValue + bnbUsdValue;
+      const totalUsd = Number(totalUsdWei) / 1e18;
+      setPortfolioUSD(totalUsd);
+      logInfo("UI: Portfolio updated", { totalUsd });
+    } catch (e) {
+      logError("UI: Portfolio refresh failed", String(e?.message || e));
+    }
+  }
+
+  useEffect(() => {
+    refreshPortfolioValue();
+  }, [account, gccWei, bnbWei]);
+
+  useEffect(() => {
+    window.refreshPortfolioValue = refreshPortfolioValue;
+    return () => { delete window.refreshPortfolioValue; };
+  }, [gccWei, bnbWei, account]);
 
   const onConnect = async () => {
     if (account) return;
@@ -58,7 +91,7 @@ export default function Portfolio({ account }) {
       </div>
       {gccErr && <span className="muted" style={{marginLeft:8}}>({gccErr})</span>}
       <button className="pill">
-        ▸ Portfolio {loading ? '' : (usd != null ? `• $${usd.toFixed(2)}` : '')}
+        ▸ Portfolio {usd != null ? `• $${usd.toFixed(2)}` : ''}
       </button>
       {isMobile() && !window.ethereum && (
         <div className="actions">

--- a/gcc-safeswap/packages/frontend/src/hooks/useGccBalance.ts
+++ b/gcc-safeswap/packages/frontend/src/hooks/useGccBalance.ts
@@ -8,6 +8,7 @@ const ERC20_ABI = [
 
 export default function useGccBalance(tokenAddress: string | undefined, account?: string | null) {
   const [balance, setBalance] = useState<number | null>(null);
+  const [raw, setRaw] = useState<bigint | null>(null);
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<null | string>(null);
 
@@ -31,8 +32,11 @@ export default function useGccBalance(tokenAddress: string | undefined, account?
         }
 
         const erc20 = new Contract(tokenAddress, ERC20_ABI, prov);
-        const [raw, dec] = await Promise.all([erc20.balanceOf(account), erc20.decimals()]);
-        if (!cancelled) setBalance(Number(formatUnits(raw, dec)));
+        const [rawBal, dec] = await Promise.all([erc20.balanceOf(account), erc20.decimals()]);
+        if (!cancelled) {
+          setBalance(Number(formatUnits(rawBal, dec)));
+          setRaw(rawBal);
+        }
       } catch (e: any) {
         if (!cancelled) {
           console.debug("GCC balance error:", e);
@@ -69,5 +73,5 @@ export default function useGccBalance(tokenAddress: string | undefined, account?
     };
   }, [account, tokenAddress]);
 
-  return { balance, loading, err };
+  return { balance, raw, loading, err };
 }


### PR DESCRIPTION
## Summary
- reject non-positive amounts server-side and expose pricebook endpoint for USD conversion
- guard against stale quotes and disable zero-amount quotes in the swap form
- compute and display portfolio USD value via new pricebook API

## Testing
- `pytest` *(fails: _csv.Error: iterator should return strings, not bytes)*

------
https://chatgpt.com/codex/tasks/task_e_68c13f09ec90832b9b612d8280b385d4