### PR TITLE
feat: build swap transactions

### DIFF
--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -112,7 +112,7 @@ export default function App() {
       <main>
         <section id="swap" className="holo">
           <div className="card">
-            <SafeSwap account={activeAccount} serverSigner={signer} />
+            <SafeSwap account={activeAccount} />
           </div>
         </section>
       </main>

--- a/gcc-safeswap/packages/frontend/src/components/Portfolio.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/Portfolio.jsx
@@ -69,6 +69,12 @@ export default function Portfolio({ account }) {
     return () => { delete window.refreshPortfolioValue; };
   }, [gccWei, bnbWei, account]);
 
+  useEffect(() => {
+    refreshPortfolioValue();
+    const id = setInterval(refreshPortfolioValue, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
   const onConnect = async () => {
     if (account) return;
     try {

--- a/gcc-safeswap/packages/frontend/src/lib/api.js
+++ b/gcc-safeswap/packages/frontend/src/lib/api.js
@@ -41,6 +41,24 @@ export async function getQuote({ fromToken, toToken, amount, slippageBps }) {
   });
 }
 
+export async function buildApproveTx({ token, owner, spender, amount }) {
+  const url = smartJoin(BASE, "/api/tx/approve");
+  return await fetchJSON(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token, owner, spender, amount: String(amount) })
+  });
+}
+
+export async function buildSwapTx({ fromToken, toToken, amountIn, minAmountOut, recipient }) {
+  const url = smartJoin(BASE, "/api/tx/swap");
+  return await fetchJSON(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fromToken, toToken, amountIn: String(amountIn), minAmountOut: String(minAmountOut), recipient })
+  });
+}
+
 export async function health() {
   const url = smartJoin(BASE, "/api/plugins/health");
   return await fetchJSON(url);


### PR DESCRIPTION
## Summary
- add ERC20/PCS router ABIs and transaction builder endpoints
- expose router in quote response for PCS swaps
- wire frontend to build & send approve and swap txs via MetaMask
- refresh portfolio pricebook every minute

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: iterator should return strings, not bytes, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c14473d0b4832ba91af1bec5e6de1f