### PR TITLE
feat: redesign layout with top header and debug drawer

### DIFF
--- a/gcc-safeswap/packages/frontend/src/components/AppHeader.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/AppHeader.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export default function AppHeader({ openSettings, toggleLogs, account }) {
+  return (
+    <header className="header">
+      <div className="brand">
+        <span className="dot" />
+        <strong>GCC SafeSwap</strong>
+        <small>for Condorians</small>
+      </div>
+      <div className="header-actions">
+        <button className="btn ghost" onClick={openSettings}>
+          <i className="icon-settings" /> Settings
+        </button>
+        <button className="btn ghost" onClick={toggleLogs}>
+          <i className="icon-terminal" /> Show Logs
+        </button>
+        <div className="divider" />
+        <NetworkBadge />
+        <WalletChip account={account} />
+      </div>
+    </header>
+  );
+}
+
+function NetworkBadge() {
+  return <div className="pill">BNB • Private RPC</div>;
+}
+
+function WalletChip({ account }) {
+  const display = account ? `${account.slice(0, 6)}…${account.slice(-4)}` : 'Connect';
+  return <div className="pill">{display}</div>;
+}

--- a/gcc-safeswap/packages/frontend/src/components/DebugDrawer.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/DebugDrawer.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { getLogs, onLogChange, clearLogs } from '../lib/logger.js';
+
+export default function DebugDrawer({ open, toggleLogs }) {
+  const [entries, setEntries] = useState(getLogs());
+
+  useEffect(() => onLogChange(setEntries), []);
+
+  const copyLogs = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(entries, null, 2));
+    } catch {}
+  };
+
+  const clear = () => {
+    clearLogs();
+    setEntries([]);
+  };
+
+  return (
+    <div className={`drawer ${open ? 'open' : ''}`}>
+      <div className="drawer-head">
+        <h3>Debug Log</h3>
+        <div className="spacer" />
+        <button className="btn tiny" onClick={copyLogs}>Copy</button>
+        <button className="btn tiny" onClick={clear}>Clear</button>
+        <button className="btn ghost" onClick={toggleLogs}>Close</button>
+      </div>
+      <pre className="logview">
+        {entries.map((e, i) => `${e.ts} [${e.level}] ${e.msg}\n`).join('')}
+      </pre>
+    </div>
+  );
+}

--- a/gcc-safeswap/packages/frontend/src/components/SwapCard.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/SwapCard.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import SafeSwap from './SafeSwap.jsx';
+
+export default function SwapCard({ account, onToggleLogs, onOpenSettings }) {
+  return (
+    <div className="card">
+      <SafeSwap account={account} />
+      <div className="form-row">
+        <button className="btn ghost" onClick={onToggleLogs}>Show Logs</button>
+        <button className="btn ghost" onClick={onOpenSettings}>Settings</button>
+      </div>
+    </div>
+  );
+}

--- a/gcc-safeswap/packages/frontend/src/components/TopBar.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/TopBar.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function TopBar() {
+  return (
+    <div className="topbar">
+      <BalancePill symbol="BNB" amount="0.0019" />
+      <BalancePill symbol="GCC" amount="589.12" />
+      <PortfolioPill usd="$0.00" />
+      <button className="btn tiny" onClick={() => {}}>↻</button>
+    </div>
+  );
+}
+
+function BalancePill({ symbol, amount }) {
+  return (
+    <div className="pill">
+      {symbol} {amount}
+    </div>
+  );
+}
+
+function PortfolioPill({ usd }) {
+  return <div className="pill">Portfolio {usd}</div>;
+}

--- a/gcc-safeswap/packages/frontend/src/layout.css
+++ b/gcc-safeswap/packages/frontend/src/layout.css
@@ -1,0 +1,86 @@
+:root{
+  --bg:#0c1116;
+  --panel:#0f1a22;
+  --panel-2:#0b141a;
+  --line:#12323b;
+  --teal:#00e0d6;
+  --muted:#9fb1b7;
+  --text:#e6f1f3;
+  --radius:14px;
+}
+
+html,body,#root,.shell{height:100%}
+body{background:var(--bg); color:var(--text); font:14px/1.4 system-ui,Segoe UI,Inter,Arial}
+
+.header{
+  position:sticky; top:0; z-index:20;
+  display:flex; align-items:center; gap:16px;
+  padding:14px 18px; border-bottom:1px solid var(--line);
+  background:linear-gradient(to bottom, rgba(12,17,22,.96), rgba(12,17,22,.85));
+  backdrop-filter: blur(6px);
+}
+.brand{display:flex; align-items:baseline; gap:10px}
+.brand .dot{width:10px; height:10px; border-radius:50%; background:var(--teal)}
+.brand small{color:var(--muted); font-weight:500}
+
+.header-actions{margin-left:auto; display:flex; align-items:center; gap:10px}
+.header-actions .divider{width:1px; height:24px; background:var(--line); margin:0 6px}
+
+.topbar{
+  display:flex; gap:10px; align-items:center;
+  padding:10px 18px; border-bottom:1px solid var(--line);
+  background:var(--panel-2);
+}
+.pill{
+  border:1px solid var(--line); background:var(--panel);
+  padding:6px 10px; border-radius:999px; display:flex; gap:8px; align-items:center;
+}
+
+.main{
+  display:grid; gap:16px; padding:18px; max-width:1200px; margin:0 auto;
+  grid-template-columns: 1fr 380px; /* desktop */
+}
+.left{min-width:0}
+.right{min-width:0; position:relative}
+
+@media (max-width: 980px){
+  .main{grid-template-columns: 1fr}
+  .right{order:3}
+}
+
+.card{
+  background:radial-gradient(120% 120% at 10% 0%, rgba(0,224,214,.06), transparent),
+             var(--panel);
+  border:1px solid var(--line); border-radius:var(--radius); padding:18px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.25);
+}
+
+.form-grid{display:grid; gap:12px}
+.form-row{display:flex; gap:12px; align-items:center}
+.form-row label{width:88px; color:var(--muted)}
+
+.select, .input{
+  flex:1; background:#071217; color:var(--text);
+  border:1px solid var(--line); border-radius:10px; padding:10px 12px;
+}
+.input:focus, .select:focus{outline:1px solid var(--teal); box-shadow:0 0 0 3px rgba(0,224,214,.15)}
+
+.btn{
+  background:#0d2026; color:var(--text); border:1px solid var(--line);
+  padding:10px 14px; border-radius:10px; cursor:pointer;
+}
+.btn:hover{border-color:#1f6369}
+.btn.ghost{background:transparent}
+.btn.tiny{padding:6px 10px; font-size:12px}
+
+.drawer{
+  position:sticky; top:86px; /* stays visible under header */
+  max-height:calc(100dvh - 100px);
+  border:1px solid var(--line); border-radius:var(--radius);
+  background:var(--panel); overflow:hidden; display:flex; flex-direction:column;
+  opacity:0; transform: translateY(8px); pointer-events:none; transition:.18s ease;
+}
+.drawer.open{opacity:1; transform:none; pointer-events:auto}
+.drawer-head{display:flex; gap:10px; align-items:center; padding:12px 12px; border-bottom:1px solid var(--line)}
+.drawer .spacer{flex:1}
+.logview{padding:12px; margin:0; overflow:auto; white-space:pre-wrap; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size:12px}

--- a/gcc-safeswap/packages/frontend/src/main.jsx
+++ b/gcc-safeswap/packages/frontend/src/main.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './styles.css';
+import './layout.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- restructure App into header, top bar, main area, and debug drawer
- add reusable header, top bar, swap card, and log drawer components
- drop in fresh CSS layout theme

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `pytest` *(fails: iterator should return strings, not bytes, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c14e8f159c832ba634da96d1e97f5a