### PR TITLE
Add wallet module and MetaMask connection buttons

### DIFF
--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -37,21 +37,17 @@ export default function App() {
     };
   }, [refreshShield]);
 
-  const activeAccount = useServer && serverSigner ? serverSigner._address : account;
-
   return (
     <>
       <div className="shell">
         <AppHeader
           openSettings={() => setSettingsOpen(true)}
           toggleLogs={() => setLogsOpen(v => !v)}
-          account={activeAccount}
         />
         <TopBar />
         <main className="main">
           <section className="left">
             <SwapCard
-              account={activeAccount}
               onOpenSettings={() => setSettingsOpen(true)}
               onToggleLogs={() => setLogsOpen(v => !v)}
             />

--- a/gcc-safeswap/packages/frontend/src/components/AppHeader.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/AppHeader.jsx
@@ -1,6 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { connectInjected, ensureBscMainnet, metamaskDeepLink } from '../lib/wallet';
 
-export default function AppHeader({ openSettings, toggleLogs, account }) {
+export default function AppHeader({ openSettings, toggleLogs }) {
+  const [account, setAccount] = useState(null);
+
+  async function onConnectBrowser() {
+    try {
+      const acc = await connectInjected();
+      await ensureBscMainnet();
+      setAccount(acc);
+    } catch (e) {
+      console.info(String(e));
+    }
+  }
+
+  const onConnectMobile = () => {
+    window.open(metamaskDeepLink(), '_blank');
+  };
+
   return (
     <header className="header">
       <div className="brand">
@@ -16,18 +33,20 @@ export default function AppHeader({ openSettings, toggleLogs, account }) {
           <i className="icon-terminal" /> Show Logs
         </button>
         <div className="divider" />
-        <NetworkBadge />
-        <WalletChip account={account} />
+        {!account ? (
+          <div className="connect-row">
+            <button className="btn" onClick={onConnectBrowser}>Connect MetaMask</button>
+            <button className="btn ghost" onClick={onConnectMobile}>Open in MetaMask App</button>
+          </div>
+        ) : (
+          <WalletChip address={account} />
+        )}
       </div>
     </header>
   );
 }
 
-function NetworkBadge() {
-  return <div className="pill">BNB • Private RPC</div>;
-}
-
-function WalletChip({ account }) {
-  const display = account ? `${account.slice(0, 6)}…${account.slice(-4)}` : 'Connect';
+function WalletChip({ address }) {
+  const display = `${address.slice(0, 6)}…${address.slice(-4)}`;
   return <div className="pill">{display}</div>;
 }

--- a/gcc-safeswap/packages/frontend/src/components/SwapCard.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/SwapCard.jsx
@@ -1,9 +1,31 @@
-import React from 'react';
+import React, { useState } from 'react';
 import SafeSwap from './SafeSwap.jsx';
+import { connectInjected, ensureBscMainnet, metamaskDeepLink } from '../lib/wallet';
 
-export default function SwapCard({ account, onToggleLogs, onOpenSettings }) {
+export default function SwapCard({ onToggleLogs, onOpenSettings }) {
+  const [account, setAccount] = useState(null);
+
+  async function connectHere() {
+    try {
+      const acc = await connectInjected();
+      await ensureBscMainnet();
+      setAccount(acc);
+    } catch (e) {
+      /* no-op */
+    }
+  }
+
   return (
     <div className="card">
+      {!account && (
+        <div className="form-row" style={{ justifyContent: 'space-between' }}>
+          <button className="btn" onClick={connectHere}>Connect MetaMask</button>
+          <button className="btn ghost" onClick={() => window.open(metamaskDeepLink(), '_blank')}>
+            Open in MetaMask App
+          </button>
+        </div>
+      )}
+
       <SafeSwap account={account} />
       <div className="form-row">
         <button className="btn ghost" onClick={onToggleLogs}>Show Logs</button>

--- a/gcc-safeswap/packages/frontend/src/layout.css
+++ b/gcc-safeswap/packages/frontend/src/layout.css
@@ -25,6 +25,10 @@ body{background:var(--bg); color:var(--text); font:14px/1.4 system-ui,Segoe UI,I
 
 .header-actions{margin-left:auto; display:flex; align-items:center; gap:10px}
 .header-actions .divider{width:1px; height:24px; background:var(--line); margin:0 6px}
+.header-actions .connect-row{display:flex; gap:8px; align-items:center}
+@media (max-width:980px){
+  .header-actions .connect-row{flex-wrap:wrap}
+}
 
 .topbar{
   display:flex; gap:10px; align-items:center;

--- a/gcc-safeswap/packages/frontend/src/lib/wallet.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/wallet.ts
@@ -1,0 +1,46 @@
+import { BrowserProvider } from "ethers";
+
+export const BSC_MAINNET = {
+  chainId: "0x38",
+  chainName: "BNB Smart Chain",
+  nativeCurrency: { name: "BNB", symbol: "BNB", decimals: 18 },
+  rpcUrls: ["https://bsc-dataseed.binance.org/"],
+  blockExplorerUrls: ["https://bscscan.com/"],
+};
+
+export function currentDappUrl() {
+  const { protocol, host, pathname, search } = window.location;
+  return `${protocol}//${host}${pathname}${search}`.replace(/\/+$/, "");
+}
+
+export function metamaskDeepLink(url = currentDappUrl()) {
+  const noProto = url.replace(/^https?:\/\//i, "");
+  return `https://metamask.app.link/dapp/${noProto}`;
+}
+
+export async function connectInjected() {
+  if (!window.ethereum) {
+    window.open(metamaskDeepLink(), "_blank");
+    throw new Error("MetaMask not found — opening deep link.");
+  }
+  const accounts = await window.ethereum.request({ method: "eth_requestAccounts" });
+  return accounts[0];
+}
+
+export async function ensureBscMainnet() {
+  const provider = new BrowserProvider(window.ethereum);
+  const net = await provider.getNetwork();
+  if (net.chainId !== 56n) {
+    try {
+      await window.ethereum.request({
+        method: "wallet_switchEthereumChain",
+        params: [{ chainId: BSC_MAINNET.chainId }],
+      });
+    } catch (e) {
+      await window.ethereum.request({
+        method: "wallet_addEthereumChain",
+        params: [BSC_MAINNET],
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add wallet helper with MetaMask deep-link utilities
- reintroduce connect controls in header and swap card
- tidy header CSS for connect button layout

## Testing
- `pytest` *(fails: iterator should return strings; etc.)*
- `npm --prefix gcc-safeswap/packages/frontend run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1589b4aa4832bb140915dd7212668