### PR TITLE
refactor: remove header ctas

### DIFF
--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -42,13 +42,14 @@ export default function App() {
       <div className="shell">
         <AppHeader
           openSettings={() => setSettingsOpen(true)}
-          toggleLogs={() => setLogsOpen(v => !v)}
+          account={account}
         />
         <TopBar />
         <main className="main">
           <section className="left">
             <SwapCard
-              onOpenSettings={() => setSettingsOpen(true)}
+              account={account}
+              setAccount={setAccount}
               onToggleLogs={() => setLogsOpen(v => !v)}
             />
           </section>

--- a/gcc-safeswap/packages/frontend/src/components/AppHeader.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/AppHeader.jsx
@@ -1,23 +1,7 @@
-import React, { useState } from 'react';
-import { connectInjected, ensureBscMainnet, metamaskDeepLink } from '../lib/wallet';
+import React from 'react';
 
-export default function AppHeader({ openSettings, toggleLogs }) {
-  const [account, setAccount] = useState(null);
-
-  async function onConnectBrowser() {
-    try {
-      const acc = await connectInjected();
-      await ensureBscMainnet();
-      setAccount(acc);
-    } catch (e) {
-      console.info(String(e));
-    }
-  }
-
-  const onConnectMobile = () => {
-    window.open(metamaskDeepLink(), '_blank');
-  };
-
+export default function AppHeader({ openSettings, account }) {
+  
   return (
     <header className="header">
       <div className="brand">
@@ -29,18 +13,8 @@ export default function AppHeader({ openSettings, toggleLogs }) {
         <button className="btn ghost" onClick={openSettings}>
           <i className="icon-settings" /> Settings
         </button>
-        <button className="btn ghost" onClick={toggleLogs}>
-          <i className="icon-terminal" /> Show Logs
-        </button>
         <div className="divider" />
-        {!account ? (
-          <div className="connect-row">
-            <button className="btn" onClick={onConnectBrowser}>Connect MetaMask</button>
-            <button className="btn ghost" onClick={onConnectMobile}>Open in MetaMask App</button>
-          </div>
-        ) : (
-          <WalletChip address={account} />
-        )}
+        {account && <WalletChip address={account} />}
       </div>
     </header>
   );

--- a/gcc-safeswap/packages/frontend/src/components/SwapCard.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/SwapCard.jsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import SafeSwap from './SafeSwap.jsx';
 import { connectInjected, ensureBscMainnet, metamaskDeepLink } from '../lib/wallet';
 
-export default function SwapCard({ onToggleLogs, onOpenSettings }) {
-  const [account, setAccount] = useState(null);
+export default function SwapCard({ account, setAccount, onToggleLogs }) {
 
   async function connectHere() {
     try {
@@ -26,11 +25,11 @@ export default function SwapCard({ onToggleLogs, onOpenSettings }) {
         </div>
       )}
 
-      <SafeSwap account={account} />
-      <div className="form-row">
+      <div className="form-row" style={{ justifyContent: 'flex-end' }}>
         <button className="btn ghost" onClick={onToggleLogs}>Show Logs</button>
-        <button className="btn ghost" onClick={onOpenSettings}>Settings</button>
       </div>
+
+      <SafeSwap account={account} />
     </div>
   );
 }

--- a/gcc-safeswap/packages/frontend/src/layout.css
+++ b/gcc-safeswap/packages/frontend/src/layout.css
@@ -24,11 +24,7 @@ body{background:var(--bg); color:var(--text); font:14px/1.4 system-ui,Segoe UI,I
 .brand small{color:var(--muted); font-weight:500}
 
 .header-actions{margin-left:auto; display:flex; align-items:center; gap:10px}
-.header-actions .divider{width:1px; height:24px; background:var(--line); margin:0 6px}
-.header-actions .connect-row{display:flex; gap:8px; align-items:center}
-@media (max-width:980px){
-  .header-actions .connect-row{flex-wrap:wrap}
-}
+.header-actions .divider{width:1px; height:24px; background:var(--line); margin:0 6px; display:inline-block}
 
 .topbar{
   display:flex; gap:10px; align-items:center;


### PR DESCRIPTION
## Summary
- remove connect and log buttons from header, leaving only settings and wallet chip
- keep connect and log controls inside SwapCard
- tidy header styles to drop connect row classes

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c15e32ae64832b867bd697fe13a490