### PR TITLE
feat: support wallet-aware private relay

### DIFF
--- a/gcc-safeswap/packages/backend/server.cjs
+++ b/gcc-safeswap/packages/backend/server.cjs
@@ -62,7 +62,7 @@ console.log("🛠️ SAFE-BOOT", JSON.stringify({
 
 // Health (aliases)
 app.get(["/api/plugins/health", "/plugins/health", "/health"], (_req, res) =>
-  res.json({ status: "ok", ts: Date.now() })
+  res.json({ ok: true, relayReady: Boolean(process.env.BLXR_AUTH), pricebook: true })
 );
 
 // ---------- Helpers ----------

--- a/gcc-safeswap/packages/frontend/src/components/SwapCard.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/SwapCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SafeSwap from './SafeSwap.jsx';
-import { connectInjected, ensureBscMainnet, metamaskDeepLink } from '../lib/wallet';
+import { connectInjected, ensureBscMainnet, metamaskDeepLink, connectCondor } from '../lib/wallet';
 
 export default function SwapCard({ account, setAccount, onToggleLogs }) {
 
@@ -8,6 +8,16 @@ export default function SwapCard({ account, setAccount, onToggleLogs }) {
     try {
       const acc = await connectInjected();
       await ensureBscMainnet();
+      setAccount(acc);
+    } catch (e) {
+      /* no-op */
+    }
+  }
+
+  async function connectCondorWallet() {
+    try {
+      const acc = await connectCondor();
+      await ensureBscMainnet((window as any).condor || (window as any).ethereum);
       setAccount(acc);
     } catch (e) {
       /* no-op */
@@ -22,6 +32,7 @@ export default function SwapCard({ account, setAccount, onToggleLogs }) {
           <button className="btn ghost" onClick={() => window.open(metamaskDeepLink(), '_blank')}>
             Open in MetaMask App
           </button>
+          <button className="btn ghost" onClick={connectCondorWallet}>Connect Condor</button>
         </div>
       )}
 

--- a/gcc-safeswap/packages/frontend/src/lib/walletCaps.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/walletCaps.ts
@@ -1,0 +1,5 @@
+export function detectCaps(ethereum: any, otherProviders?: any) {
+  const isMetaMask = !!ethereum?.isMetaMask;
+  const isCondor   = !!(ethereum?.isCondor || (otherProviders?.condor?.isCondor));
+  return { isMetaMask, isCondor };
+}


### PR DESCRIPTION
## Summary
- expose relay readiness on `/api/plugins/health`
- add Condor wallet detection and connection helpers
- show Condor-only private relay toggle with marketing copy

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: csv iterator should return strings, AttributeError, etc.)*
- `npm test` in `gcc-safeswap/packages/frontend` *(fails: Missing script "test")*
- `npm test` in `gcc-safeswap/packages/backend` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1d93a9914832bb4bcd82cbc5c1aac