### PR TITLE
fix(frontend): migrate SwapCard to TypeScript

### DIFF
--- a/gcc-safeswap/packages/frontend/package.json
+++ b/gcc-safeswap/packages/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "ethers": "^6.6.0",
@@ -14,6 +15,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^4.4.9"
+    "vite": "^4.4.9",
+    "typescript": "^5.2.2",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   }
 }

--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import AppHeader from './components/AppHeader.jsx';
 import TopBar from './components/TopBar.jsx';
-import SwapCard from './components/SwapCard.jsx';
+import SwapCard from './components/SwapCard.tsx';
 import DebugDrawer from './components/DebugDrawer.jsx';
 import WalletUnlockModal from './components/WalletUnlockModal.jsx';
 import SettingsDrawer from './components/SettingsDrawer.jsx';

--- a/gcc-safeswap/packages/frontend/src/components/SafeSwap.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/SafeSwap.jsx
@@ -122,7 +122,7 @@ export default function SafeSwap({ account }) {
       const url = cfg?.rpcUrl || '';
       setRpcLabel(lbl);
       setRpcUrl(url);
-      setCaps(detectCaps((window as any).ethereum, (window as any)));
+      setCaps(detectCaps(window.ethereum, window));
     }
     init();
     const onChainChanged = () => {
@@ -131,7 +131,7 @@ export default function SafeSwap({ account }) {
       const url = cfg?.rpcUrl || '';
       setRpcLabel(lbl);
       setRpcUrl(url);
-      setCaps(detectCaps((window as any).ethereum, (window as any)));
+      setCaps(detectCaps(window.ethereum, window));
     };
     window.ethereum?.on('chainChanged', onChainChanged);
     return () => window.ethereum?.removeListener('chainChanged', onChainChanged);

--- a/gcc-safeswap/packages/frontend/src/components/SwapCard.tsx
+++ b/gcc-safeswap/packages/frontend/src/components/SwapCard.tsx
@@ -2,7 +2,15 @@ import React from 'react';
 import SafeSwap from './SafeSwap.jsx';
 import { connectInjected, ensureBscMainnet, metamaskDeepLink, connectCondor, getCondorProvider } from '../lib/wallet';
 
-export default function SwapCard({ account, setAccount, onToggleLogs }) {
+interface SwapCardProps {
+  account: string | null;
+  setAccount: React.Dispatch<React.SetStateAction<string | null>>;
+  onToggleLogs: () => void;
+}
+
+export default function SwapCard({ account, setAccount, onToggleLogs }: SwapCardProps) {
+  const eth = typeof window !== "undefined" ? window.ethereum : undefined;
+  const condor = typeof window !== "undefined" ? window.condor ?? undefined : undefined;
 
   async function connectHere() {
     try {
@@ -17,7 +25,7 @@ export default function SwapCard({ account, setAccount, onToggleLogs }) {
   async function connectCondorWallet() {
     try {
       const acc = await connectCondor();
-      await ensureBscMainnet(getCondorProvider() || (window as any).ethereum);
+      await ensureBscMainnet(getCondorProvider() || condor || eth);
       setAccount(acc);
     } catch (e) {
       /* no-op */

--- a/gcc-safeswap/packages/frontend/src/types/wallets.d.ts
+++ b/gcc-safeswap/packages/frontend/src/types/wallets.d.ts
@@ -1,0 +1,15 @@
+interface Eip1193Provider {
+  isMetaMask?: boolean;
+  isCondor?: boolean;
+  request(args: { method: string; params?: any[] }): Promise<any>;
+  on?(event: "accountsChanged" | "chainChanged", handler: (data: any) => void): void;
+  removeListener?(event: "accountsChanged" | "chainChanged", handler: (data: any) => void): void;
+}
+
+declare global {
+  interface Window {
+    ethereum?: Eip1193Provider & { providers?: Eip1193Provider[] };
+    condor?: Eip1193Provider; // our wallet
+  }
+}
+export {};

--- a/gcc-safeswap/packages/frontend/tsconfig.json
+++ b/gcc-safeswap/packages/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowJs": true,
+    "checkJs": false
+  },
+  "include": ["src"]
+}

--- a/gcc-safeswap/tsconfig.base.json
+++ b/gcc-safeswap/tsconfig.base.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  }
+}


### PR DESCRIPTION
## Summary
- migrate SwapCard component to TypeScript with explicit wallet typings
- configure frontend TypeScript compiler options
- remove stray TS casts in SafeSwap and update imports

## Testing
- `yarn typecheck` *(fails: package doesn't seem to be present in lockfile)*
- `yarn build` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e47b80b8832b9f024bbddad8bc25