### PR TITLE
feat: show dynamic portfolio value

### DIFF
--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -44,7 +44,7 @@ export default function App() {
           openSettings={() => setSettingsOpen(true)}
           account={account}
         />
-        <TopBar />
+        <TopBar account={account} />
         <main className="main">
           <section className="left">
             <SwapCard

--- a/gcc-safeswap/packages/frontend/src/components/SafeSwap.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/SafeSwap.jsx
@@ -166,7 +166,7 @@ export default function SafeSwap({ account }) {
       setQuote(data);
       setLastParams({ sellAmount });
       setStatus('Quote ready');
-      window.refreshPortfolioValue?.();
+      window.dispatchEvent(new Event("portfolio:refresh"));
   } catch (e) {
       if (seq !== quoteSeq) return;
       const raw = String(e?.message || e);
@@ -219,8 +219,9 @@ export default function SafeSwap({ account }) {
       logInfo("Swap submitted", submit);
 
       window.showToast?.("Swap submitted");
-      setTimeout(() => window.refreshPortfolioValue?.(), 12_000);
-      setTimeout(() => window.refreshPortfolioValue?.(), 30_000);
+      window.dispatchEvent(new Event("swap:completed"));
+      setTimeout(() => window.dispatchEvent(new Event("swap:completed")), 12_000);
+      setTimeout(() => window.dispatchEvent(new Event("swap:completed")), 30_000);
     } catch (e) {
       const raw = String(e?.message || e);
       logError("Swap failed", raw);

--- a/gcc-safeswap/packages/frontend/src/components/TopBar.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/TopBar.jsx
@@ -1,12 +1,21 @@
 import React from 'react';
+import { usePortfolio } from '../hooks/usePortfolio';
 
-export default function TopBar() {
+export default function TopBar({ account }) {
+  const { totalUsd, bnb, gcc } = usePortfolio(account);
+
+  const fmtUsd = (n) =>
+    n === 0 ? "$0.00" :
+    (n < 1 ? `$${n.toFixed(4)}` : `$${n.toLocaleString(undefined, { maximumFractionDigits: 2 })}`);
+
+  const fmtToken = (n, dec) => account ? n.toFixed(dec) : '—';
+
   return (
-    <div className="topbar">
-      <BalancePill symbol="BNB" amount="0.0019" />
-      <BalancePill symbol="GCC" amount="589.12" />
-      <PortfolioPill usd="$0.00" />
-      <button className="btn tiny" onClick={() => {}}>↻</button>
+    <div className="topbar badges-row">
+      <BalancePill symbol="BNB" amount={fmtToken(bnb, 4)} />
+      <BalancePill symbol="GCC" amount={fmtToken(gcc, 2)} />
+      <PortfolioPill usd={fmtUsd(totalUsd)} />
+      <RefreshButton onClick={() => window.dispatchEvent(new Event('portfolio:refresh'))} />
     </div>
   );
 }
@@ -21,4 +30,10 @@ function BalancePill({ symbol, amount }) {
 
 function PortfolioPill({ usd }) {
   return <div className="pill">Portfolio {usd}</div>;
+}
+
+function RefreshButton({ onClick }) {
+  return (
+    <button className="btn tiny" onClick={onClick}>↻</button>
+  );
 }

--- a/gcc-safeswap/packages/frontend/src/hooks/usePortfolio.ts
+++ b/gcc-safeswap/packages/frontend/src/hooks/usePortfolio.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { BrowserProvider } from "ethers";
+import { getBalancesUSD } from "../lib/portfolio";
+
+export function usePortfolio(account?: string) {
+  const [state, setState] = useState<{ totalUsd: number; bnb: number; gcc: number }>({
+    totalUsd: 0,
+    bnb: 0,
+    gcc: 0
+  });
+  const timer = useRef<number | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!account || typeof window === "undefined") return;
+    try {
+      const provider = new BrowserProvider((window as any).ethereum ?? (window as any).condor, "any");
+      const res = await getBalancesUSD(provider, account);
+      setState(s => ({ ...s, totalUsd: res.totalUsd, bnb: res.bnb, gcc: res.gcc }));
+    } catch {
+      // keep last good state
+    }
+  }, [account]);
+
+  useEffect(() => {
+    if (!account) return;
+    refresh();
+    if (timer.current) window.clearInterval(timer.current);
+    timer.current = window.setInterval(refresh, 60_000) as any;
+    return () => {
+      if (timer.current) window.clearInterval(timer.current);
+    };
+  }, [account, refresh]);
+
+  useEffect(() => {
+    const eth = (window as any).ethereum ?? (window as any).condor;
+    if (!eth?.on) return;
+    const onAccounts = () => refresh();
+    const onChain = () => refresh();
+    eth.on("accountsChanged", onAccounts);
+    eth.on("chainChanged", onChain);
+    return () => {
+      eth.removeListener?.("accountsChanged", onAccounts);
+      eth.removeListener?.("chainChanged", onChain);
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    const handler = () => refresh();
+    window.addEventListener("portfolio:refresh", handler);
+    window.addEventListener("swap:completed", handler);
+    return () => {
+      window.removeEventListener("portfolio:refresh", handler);
+      window.removeEventListener("swap:completed", handler);
+    };
+  }, [refresh]);
+
+  return state; // { totalUsd, bnb, gcc }
+}

--- a/gcc-safeswap/packages/frontend/src/lib/portfolio.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/portfolio.ts
@@ -1,0 +1,33 @@
+import { BrowserProvider, Contract, formatEther, formatUnits } from "ethers";
+
+const GCC = import.meta.env.VITE_TOKEN_GCC as string;
+const GCC_DECIMALS = Number(import.meta.env.VITE_GCC_DECIMALS ?? 18);
+const API_BASE = import.meta.env.VITE_API_BASE as string;
+
+const ERC20_ABI = [
+  "function balanceOf(address) view returns (uint256)",
+  "function decimals() view returns (uint8)"
+];
+
+export async function getBalancesUSD(provider: BrowserProvider, account: string) {
+  const [bnbWei, pricebook] = await Promise.all([
+    provider.getBalance(account),
+    fetch(`${API_BASE}/api/pricebook`).then(r => r.json())
+  ]);
+
+  const bnb = Number(formatEther(bnbWei));
+  const bnbUsd = Number(pricebook.BNB_USD ?? 0);
+
+  const erc20 = new Contract(GCC, ERC20_ABI, provider);
+  const gccRaw: bigint = await erc20.balanceOf(account);
+  const gcc = Number(formatUnits(gccRaw, GCC_DECIMALS));
+
+  let gccUsd = Number(pricebook.GCC_USD ?? 0);
+  if (!gccUsd && pricebook.GCC_BNB && bnbUsd) gccUsd = Number(pricebook.GCC_BNB) * bnbUsd;
+
+  const totalUsd = (bnb * bnbUsd) + (gcc * gccUsd);
+
+  return {
+    bnb, gcc, bnbUsd, gccUsd, totalUsd
+  };
+}


### PR DESCRIPTION
## Summary
- compute BNB and GCC balances in USD
- auto-refresh portfolio badge via polling, wallet events, and swap completion events
- expose refresh button to manually reload portfolio value

## Testing
- `yarn install` *(fails: RequestError: Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ec42e0f0832bb9c244feffce675b