### PR TITLE
fix portfolio usd total and pricebook handling

### DIFF
--- a/gcc-safeswap/packages/frontend/src/components/TopBar.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/TopBar.jsx
@@ -5,7 +5,7 @@ export default function TopBar({ account }) {
   const { totalUsd, bnb, gcc } = usePortfolio(account);
 
   const fmtUsd = (n) =>
-    n === 0 ? "$0.00" :
+    n <= 0 ? "$0.00" :
     (n < 1 ? `$${n.toFixed(4)}` : `$${n.toLocaleString(undefined, { maximumFractionDigits: 2 })}`);
 
   const fmtToken = (n, dec) => account ? n.toFixed(dec) : '—';

--- a/gcc-safeswap/packages/frontend/src/hooks/usePortfolio.ts
+++ b/gcc-safeswap/packages/frontend/src/hooks/usePortfolio.ts
@@ -1,58 +1,69 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BrowserProvider } from "ethers";
-import { getBalancesUSD } from "../lib/portfolio";
+import { computePortfolioUSD } from "../lib/portfolio";
+
+type State = { totalUsd: number; bnb: number; gcc: number };
 
 export function usePortfolio(account?: string) {
-  const [state, setState] = useState<{ totalUsd: number; bnb: number; gcc: number }>({
-    totalUsd: 0,
-    bnb: 0,
-    gcc: 0
-  });
+  const [state, setState] = useState<State>({ totalUsd: 0, bnb: 0, gcc: 0 });
   const timer = useRef<number | null>(null);
 
   const refresh = useCallback(async () => {
     if (!account || typeof window === "undefined") return;
+    const eth: any = (window as any).ethereum ?? (window as any).condor;
+    if (!eth) return;
+
+    const provider = new BrowserProvider(eth, "any");
+    const res = await computePortfolioUSD(provider, account);
+
+    // send to in-app Debug Log if available
     try {
-      const provider = new BrowserProvider((window as any).ethereum ?? (window as any).condor, "any");
-      const res = await getBalancesUSD(provider, account);
-      setState(s => ({ ...s, totalUsd: res.totalUsd, bnb: res.bnb, gcc: res.gcc }));
-    } catch {
-      // keep last good state
-    }
+      (window as any).__log?.("UI: Portfolio updated", {
+        bnb: res.bnb,
+        gcc: res.gcc,
+        bnbUsd: res.bnbUsd,
+        gccUsd: res.gccUsd,
+        totalUsd: res.totalUsd,
+      });
+    } catch {}
+
+    setState({ totalUsd: res.totalUsd, bnb: res.bnb, gcc: res.gcc });
   }, [account]);
 
   useEffect(() => {
     if (!account) return;
     refresh();
     if (timer.current) window.clearInterval(timer.current);
-    timer.current = window.setInterval(refresh, 60_000) as any;
+    timer.current = window.setInterval(refresh, 60_000) as any; // 60s
     return () => {
       if (timer.current) window.clearInterval(timer.current);
     };
   }, [account, refresh]);
 
+  // react to swaps & manual refresh
   useEffect(() => {
-    const eth = (window as any).ethereum ?? (window as any).condor;
+    const handle = () => refresh();
+    window.addEventListener("swap:completed", handle);
+    window.addEventListener("portfolio:refresh", handle);
+    return () => {
+      window.removeEventListener("swap:completed", handle);
+      window.removeEventListener("portfolio:refresh", handle);
+    };
+  }, [refresh]);
+
+  // react to wallet events
+  useEffect(() => {
+    const eth: any = (window as any).ethereum ?? (window as any).condor;
     if (!eth?.on) return;
-    const onAccounts = () => refresh();
+    const onAcc = () => refresh();
     const onChain = () => refresh();
-    eth.on("accountsChanged", onAccounts);
+    eth.on("accountsChanged", onAcc);
     eth.on("chainChanged", onChain);
     return () => {
-      eth.removeListener?.("accountsChanged", onAccounts);
+      eth.removeListener?.("accountsChanged", onAcc);
       eth.removeListener?.("chainChanged", onChain);
     };
   }, [refresh]);
 
-  useEffect(() => {
-    const handler = () => refresh();
-    window.addEventListener("portfolio:refresh", handler);
-    window.addEventListener("swap:completed", handler);
-    return () => {
-      window.removeEventListener("portfolio:refresh", handler);
-      window.removeEventListener("swap:completed", handler);
-    };
-  }, [refresh]);
-
-  return state; // { totalUsd, bnb, gcc }
+  return state;
 }

--- a/gcc-safeswap/packages/frontend/src/lib/portfolio.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/portfolio.ts
@@ -1,33 +1,35 @@
 import { BrowserProvider, Contract, formatEther, formatUnits } from "ethers";
+import { getPrices } from "./pricebook";
 
 const GCC = import.meta.env.VITE_TOKEN_GCC as string;
 const GCC_DECIMALS = Number(import.meta.env.VITE_GCC_DECIMALS ?? 18);
-const API_BASE = import.meta.env.VITE_API_BASE as string;
 
 const ERC20_ABI = [
-  "function balanceOf(address) view returns (uint256)",
-  "function decimals() view returns (uint8)"
+  "function balanceOf(address) view returns (uint256)"
 ];
 
-export async function getBalancesUSD(provider: BrowserProvider, account: string) {
-  const [bnbWei, pricebook] = await Promise.all([
+export async function readBalances(
+  provider: BrowserProvider,
+  account: string
+) {
+  const [bnbWei, gccRaw] = await Promise.all([
     provider.getBalance(account),
-    fetch(`${API_BASE}/api/pricebook`).then(r => r.json())
+    new Contract(GCC, ERC20_ABI, provider).balanceOf(account),
   ]);
-
-  const bnb = Number(formatEther(bnbWei));
-  const bnbUsd = Number(pricebook.BNB_USD ?? 0);
-
-  const erc20 = new Contract(GCC, ERC20_ABI, provider);
-  const gccRaw: bigint = await erc20.balanceOf(account);
-  const gcc = Number(formatUnits(gccRaw, GCC_DECIMALS));
-
-  let gccUsd = Number(pricebook.GCC_USD ?? 0);
-  if (!gccUsd && pricebook.GCC_BNB && bnbUsd) gccUsd = Number(pricebook.GCC_BNB) * bnbUsd;
-
-  const totalUsd = (bnb * bnbUsd) + (gcc * gccUsd);
-
   return {
-    bnb, gcc, bnbUsd, gccUsd, totalUsd
+    bnb: Number(formatEther(bnbWei)),
+    gcc: Number(formatUnits(gccRaw, GCC_DECIMALS)),
   };
+}
+
+export async function computePortfolioUSD(
+  provider: BrowserProvider,
+  account: string
+) {
+  const [{ bnb, gcc }, { bnbUsd, gccUsd }] = await Promise.all([
+    readBalances(provider, account),
+    getPrices(),
+  ]);
+  const totalUsd = bnb * bnbUsd + gcc * gccUsd;
+  return { bnb, gcc, bnbUsd, gccUsd, totalUsd };
 }

--- a/gcc-safeswap/packages/frontend/src/lib/pricebook.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/pricebook.ts
@@ -1,0 +1,32 @@
+const API_BASE = import.meta.env.VITE_API_BASE as string;
+
+export type Pricebook = {
+  BNB_USD?: number;
+  GCC_USD?: number;
+  GCC_BNB?: number;
+  prices?: { BNB_USD?: number; GCC_USD?: number; GCC_BNB?: number };
+  // accept any other shapes the backend might return
+  [k: string]: any;
+};
+
+export async function getPrices(): Promise<{ bnbUsd: number; gccUsd: number }> {
+  try {
+    const res = await fetch(`${API_BASE}/api/pricebook`, { cache: "no-store" });
+    if (!res.ok) throw new Error(`pricebook ${res.status}`);
+    const pb: Pricebook = await res.json();
+
+    // Try multiple shapes/keys safely
+    const bnbUsd =
+      Number(pb.BNB_USD ?? pb?.prices?.BNB_USD ?? pb?.bnbUsd ?? 0) || 0;
+
+    // Prefer direct GCC_USD, else derive from GCC_BNB * BNB_USD
+    const gccUsdDirect = Number(pb.GCC_USD ?? pb?.prices?.GCC_USD ?? 0) || 0;
+    const gccBnb = Number(pb.GCC_BNB ?? pb?.prices?.GCC_BNB ?? 0) || 0;
+    const gccUsd = gccUsdDirect || (gccBnb && bnbUsd ? gccBnb * bnbUsd : 0);
+
+    return { bnbUsd, gccUsd };
+  } catch (e) {
+    // last-resort zeros (don't throw—avoids $0 flicker on network blips)
+    return { bnbUsd: 0, gccUsd: 0 };
+  }
+}


### PR DESCRIPTION
## Summary
- harden pricebook helper and derive GCC/USD from GCC/BNB
- compute portfolio balances in USD with price fallback and debug logging
- refresh top bar badge and polling for portfolio value

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Cannot find module 'react' and others)
- `pytest` (fails: _csv.Error and other failures)


------
https://chatgpt.com/codex/tasks/task_e_68c1f05b85f8832b94cf0de4903e7612