### PR TITLE
feat: add pricebook endpoint for portfolio

### DIFF
--- a/gcc-safeswap/packages/backend/routes/pricebook.js
+++ b/gcc-safeswap/packages/backend/routes/pricebook.js
@@ -1,0 +1,55 @@
+const router = require("express").Router();
+const fetch = (...args) => import("node-fetch").then(({ default: f }) => f(...args));
+
+// simple in-memory cache
+let cache = null;
+let cacheTs = 0;
+const TTL_MS = 60_000;
+
+router.get("/", async (_req, res) => {
+  try {
+    const now = Date.now();
+    if (cache && now - cacheTs < TTL_MS) return res.json(cache);
+
+    const GCC = (process.env.TOKEN_GCC || "").toLowerCase();
+    const WBNB = (process.env.TOKEN_WBNB || "").toLowerCase();
+
+    // 1) WBNB → USD (Dexscreener reports many pairs; prefer stable-quoted)
+    const wbnbTok = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${WBNB}`).then(r => r.json());
+    const wbnbUsd = pickBestUsd(wbnbTok, WBNB);
+
+    // 2) GCC → WBNB via Dexscreener token endpoint (GCC pairs)
+    const gccTok = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${GCC}`).then(r => r.json());
+    const gccToWbnb = pickBestNative(gccTok, GCC); // native = WBNB
+    const gccUsd = gccToWbnb * wbnbUsd;
+
+    cache = { bnbUsd: wbnbUsd, wbnbUsd, gccUsd };
+    cacheTs = now;
+    return res.json(cache);
+  } catch (e) {
+    if (cache) return res.json(cache);
+    return res.status(502).json({ error: "price_fetch_failed" });
+  }
+});
+
+function pickBestUsd(resp, baseAddr) {
+  // Prefer quoteToken that is a USD stable (BUSD/USDT/USDC), fallback to first priceUsd provided
+  const stables = new Set(["busd", "usdt", "usdc"]);
+  const pairs = resp?.pairs || [];
+  const stable = pairs.find(p =>
+    p.baseToken?.address?.toLowerCase() === baseAddr &&
+    p.priceUsd &&
+    stables.has(p.quoteToken?.address?.toLowerCase?.() || p.quoteToken?.symbol?.toLowerCase?.())
+  );
+  const anyUsd = pairs.find(p => p.baseToken?.address?.toLowerCase() === baseAddr && p.priceUsd);
+  return Number(stable?.priceUsd || anyUsd?.priceUsd || 0);
+}
+
+function pickBestNative(resp, baseAddr) {
+  const pairs = resp?.pairs || [];
+  // Prefer pairs whose quote is WBNB (native on BSC for Dexscreener priceNative)
+  const withNative = pairs.find(p => p.baseToken?.address?.toLowerCase() === baseAddr && p.priceNative);
+  return Number(withNative?.priceNative || 0);
+}
+
+module.exports = router;

--- a/gcc-safeswap/packages/backend/server.cjs
+++ b/gcc-safeswap/packages/backend/server.cjs
@@ -67,6 +67,8 @@ app.get(["/api/plugins/health", "/plugins/health", "/health"], (_req, res) =>
 
 // Private RPC chain parameters
 app.use("/api/private-rpc", require("./routes/privateRpc"));
+// Token price lookup
+app.use("/api/pricebook", require("./routes/pricebook"));
 
 // ---------- Helpers ----------
 const _decimalsCache = new Map();


### PR DESCRIPTION
## Summary
- add `/api/pricebook` endpoint that sources BNB and GCC prices from Dexscreener with 60s cache
- wire backend server to expose new pricebook endpoint

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c1fa165f98832b99109f0826d628ae