### PR TITLE
Restore MetaMask deep-link and wallet connect strip

### DIFF
--- a/gcc-safeswap/packages/frontend/src/App.jsx
+++ b/gcc-safeswap/packages/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import SwapCard from './components/SwapCard.tsx';
 import DebugDrawer from './components/DebugDrawer.jsx';
 import WalletUnlockModal from './components/WalletUnlockModal.jsx';
 import SettingsDrawer from './components/SettingsDrawer.jsx';
+import { WalletConnect } from './components/WalletConnect.tsx';
 import useShieldStatus from './hooks/useShieldStatus.js';
 import { ServerSigner } from './lib/serverSigner.js';
 import { getBrowserProvider } from './lib/ethers.js';
@@ -18,14 +19,16 @@ export default function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [logsOpen, setLogsOpen] = useState(false);
 
+  async function refreshAccount() {
+    try {
+      const prov = getBrowserProvider();
+      const acc = await prov.send('eth_accounts', []);
+      setAccount(acc?.[0] || null);
+    } catch {}
+  }
+
   useEffect(() => {
-    (async () => {
-      try {
-        const prov = getBrowserProvider();
-        const acc = await prov.send('eth_accounts', []);
-        if (acc?.[0]) setAccount(acc[0]);
-      } catch {}
-    })();
+    (async () => { await refreshAccount(); })();
 
     if (!window.ethereum) return;
     const onAccountsChanged = a => setAccount(a?.[0] || '');
@@ -47,6 +50,7 @@ export default function App() {
         <TopBar account={account} />
         <main className="main">
           <section className="left">
+            <WalletConnect onConnected={refreshAccount} />
             <SwapCard
               account={account}
               setAccount={setAccount}

--- a/gcc-safeswap/packages/frontend/src/components/SafeSwap.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/SafeSwap.jsx
@@ -6,7 +6,7 @@ import { fromBase, toBase } from '../lib/format';
 import { logInfo, logError, logWarn, clearLogs } from '../lib/logger.js';
 import TokenSelect from './TokenSelect.jsx';
 import { getCondorProvider } from '../lib/wallet';
-import { isCondorProvider } from '../lib/walletDetect';
+import { isCondorEnv } from '../lib/walletDetect';
 
 let inflight;
 let quoteSeq = 0;
@@ -114,11 +114,11 @@ export default function SafeSwap({ account }) {
       } catch {
         setNetworkOk(false);
       }
-      setIsCondor(isCondorProvider(window.ethereum));
+      setIsCondor(isCondorEnv());
     }
     init();
     const onChainChanged = () => {
-      setIsCondor(isCondorProvider(window.ethereum));
+      setIsCondor(isCondorEnv());
     };
     window.ethereum?.on('chainChanged', onChainChanged);
     return () => window.ethereum?.removeListener('chainChanged', onChainChanged);

--- a/gcc-safeswap/packages/frontend/src/components/SwapCard.tsx
+++ b/gcc-safeswap/packages/frontend/src/components/SwapCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import SafeSwap from './SafeSwap.jsx';
 import { connectInjected, connectCondor } from '../lib/wallet';
+import { isMetaMaskEnv, isCondorEnv } from '../lib/walletDetect';
 
 interface SwapCardProps {
   account: string | null;
@@ -28,12 +29,20 @@ export default function SwapCard({ account, setAccount, onToggleLogs }: SwapCard
     }
   }
 
+  const hasMetaMask = isMetaMaskEnv();
+  const hasCondor = isCondorEnv();
+  const canConnect = hasMetaMask || hasCondor;
+
   return (
     <div className="card">
-      {!account && (
+      {!account && canConnect && (
         <div className="form-row" style={{ justifyContent: 'space-between' }}>
-          <button className="btn" onClick={connectHere}>Connect MetaMask</button>
-          <button className="btn ghost" onClick={connectCondorWallet}>Connect Condor</button>
+          {hasMetaMask && (
+            <button className="btn" onClick={connectHere}>Connect MetaMask</button>
+          )}
+          {hasCondor && (
+            <button className="btn ghost" onClick={connectCondorWallet}>Connect Condor</button>
+          )}
         </div>
       )}
 

--- a/gcc-safeswap/packages/frontend/src/components/WalletConnect.tsx
+++ b/gcc-safeswap/packages/frontend/src/components/WalletConnect.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { isMetaMaskEnv, isCondorEnv, isMobileBrowser, buildMetaMaskDeeplink } from "../lib/walletDetect";
+
+export function WalletConnect({ onConnected }:{ onConnected:()=>void }) {
+  const [busy, setBusy] = useState(false);
+  const mm = isMetaMaskEnv();
+  const condor = isCondorEnv();
+  const showDeepLink = isMobileBrowser(); // not already in MetaMask
+
+  if (mm || condor) return null; // already in a wallet, let the main UI handle it
+
+  return (
+    <div className="card card--connect">
+      <div className="title">Connect a wallet</div>
+      <div className="row gap">
+        <button
+          onClick={async () => {
+            try {
+              setBusy(true);
+              const eth:any = (window as any).ethereum;
+              if (!eth?.request) throw new Error("No EIP-1193 provider found");
+              await eth.request({ method: "eth_requestAccounts" });
+              onConnected();
+            } finally { setBusy(false); }
+          }}
+          disabled={busy}
+        >
+          {busy ? "Connecting…" : "Connect MetaMask"}
+        </button>
+
+        {showDeepLink && (
+          <a className="ghost" href={buildMetaMaskDeeplink()} target="_blank" rel="noreferrer">
+            Open in MetaMask App
+          </a>
+        )}
+      </div>
+      <small className="muted">You can also use Condor Wallet for private routing.</small>
+    </div>
+  );
+}

--- a/gcc-safeswap/packages/frontend/src/lib/walletDetect.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/walletDetect.ts
@@ -1,6 +1,13 @@
-export function isCondorProvider(eth: any) {
-  return !!eth?.isCondor || !!(window as any).condor?.isCondor;
-}
-export function isMetaMaskProvider(eth: any) {
-  return !!eth?.isMetaMask;
+export const isMetaMaskEnv = () => !!(window as any).ethereum?.isMetaMask;
+export const isCondorEnv   = () => !!(window as any).ethereum?.isCondor || !!(window as any).condor?.isCondor;
+
+export const isMobileBrowser = () => /Android|iPhone|iPad|iPod/i.test(navigator.userAgent) &&
+                                     !isMetaMaskEnv(); // exclude in-app MM webview
+
+export function buildMetaMaskDeeplink(): string {
+  // dapp deeplink preserves path & query
+  const origin = location.host;              // e.g. gcc-me-vprotect.vercel.app
+  const path   = location.pathname + location.search + location.hash;
+  // IMPORTANT: use https scheme, MetaMask requires https
+  return `https://metamask.app.link/dapp/${origin}${path}`;
 }


### PR DESCRIPTION
## Summary
- add wallet detection helpers and MetaMask deep-link builder
- introduce WalletConnect component for MetaMask connect and mobile app deep-link
- conditionally show connect buttons and keep Condor private toggle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: modules and typings missing)*
- `pytest` *(fails: multiple tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c203e0feb8832ba3f6ebeca14591ad