### PR TITLE
feat: add wallet badge and portfolio pricing

### DIFF
--- a/gcc-safeswap/packages/backend/config/env.js
+++ b/gcc-safeswap/packages/backend/config/env.js
@@ -9,6 +9,11 @@ if (raw.GCC_ADDRESS && !raw.TOKEN_GCC) raw.TOKEN_GCC = raw.GCC_ADDRESS;
 if (raw.TOKEN_GCC && !raw.GCC_ADDRESS) raw.GCC_ADDRESS = raw.TOKEN_GCC;
 if (raw.WBNB_ADDRESS && !raw.TOKEN_WBNB) raw.TOKEN_WBNB = raw.WBNB_ADDRESS;
 if (raw.TOKEN_WBNB && !raw.WBNB_ADDRESS) raw.WBNB_ADDRESS = raw.TOKEN_WBNB;
+// support both old and new Dexscreener pair env vars
+if (raw.DEXSCREENER_PAIR_GCC_WBNB && !raw.PAIR_GCC_WBNB)
+  raw.PAIR_GCC_WBNB = raw.DEXSCREENER_PAIR_GCC_WBNB;
+if (raw.PAIR_GCC_WBNB && !raw.DEXSCREENER_PAIR_GCC_WBNB)
+  raw.DEXSCREENER_PAIR_GCC_WBNB = raw.PAIR_GCC_WBNB;
 Object.assign(process.env, raw);
 
 const env = envalid.cleanEnv(raw, {
@@ -37,6 +42,7 @@ const env = envalid.cleanEnv(raw, {
   RELAYER_FROM_ADDRESS: str({ default: '' }),
 
   COINGECKO_ID:  str({ default: '' }),
+  PAIR_GCC_WBNB: str({ default: '' }),
   DEXSCREENER_PAIR_GCC_WBNB: str({ default: '' }),
 
   LOG_LEVEL:     str({ default: 'info' }),

--- a/gcc-safeswap/packages/backend/routes/pricebook.js
+++ b/gcc-safeswap/packages/backend/routes/pricebook.js
@@ -1,55 +1,59 @@
 const router = require("express").Router();
 const fetch = (...args) => import("node-fetch").then(({ default: f }) => f(...args));
 
-// simple in-memory cache
 let cache = null;
-let cacheTs = 0;
-const TTL_MS = 60_000;
+let ts = 0;
+const TTL = 60_000;
 
 router.get("/", async (_req, res) => {
   try {
-    const now = Date.now();
-    if (cache && now - cacheTs < TTL_MS) return res.json(cache);
+    if (cache && Date.now() - ts < TTL) return res.json(cache);
 
     const GCC = (process.env.TOKEN_GCC || "").toLowerCase();
     const WBNB = (process.env.TOKEN_WBNB || "").toLowerCase();
+    const PAIR = (process.env.PAIR_GCC_WBNB || "").toLowerCase();
 
-    // 1) WBNB → USD (Dexscreener reports many pairs; prefer stable-quoted)
-    const wbnbTok = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${WBNB}`).then(r => r.json());
-    const wbnbUsd = pickBestUsd(wbnbTok, WBNB);
+    // (A) GCC per WBNB from a pinned pair
+    let gccPerWbnb = 0;
+    if (PAIR) {
+      const byPair = await fetch(`https://api.dexscreener.com/latest/dex/pairs/bsc/${PAIR}`).then(r => r.json());
+      const p = byPair?.pair;
+      if (
+        p?.baseToken?.address?.toLowerCase() === GCC &&
+        p?.quoteToken?.address?.toLowerCase() === WBNB &&
+        p?.priceNative
+      ) {
+        gccPerWbnb = Number(p.priceNative);
+      }
+    }
+    // (B) Fallback: token search (if PAIR not set or invalid)
+    if (!gccPerWbnb) {
+      const tok = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${GCC}`).then(r => r.json());
+      const p = (tok?.pairs || []).find(x =>
+        x.baseToken?.address?.toLowerCase() === GCC &&
+        x.quoteToken?.address?.toLowerCase() === WBNB &&
+        x.priceNative
+      );
+      gccPerWbnb = Number(p?.priceNative || 0);
+    }
 
-    // 2) GCC → WBNB via Dexscreener token endpoint (GCC pairs)
-    const gccTok = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${GCC}`).then(r => r.json());
-    const gccToWbnb = pickBestNative(gccTok, GCC); // native = WBNB
-    const gccUsd = gccToWbnb * wbnbUsd;
+    // WBNB → USD: prefer stable-quoted pairs
+    const wTok = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${WBNB}`).then(r => r.json());
+    const stables = new Set(["usdt", "usdc", "busd"]);
+    const stablePair = (wTok?.pairs || []).find(p =>
+      p.baseToken?.address?.toLowerCase() === WBNB &&
+      p.priceUsd &&
+      stables.has(p?.quoteToken?.symbol?.toLowerCase?.())
+    ) || (wTok?.pairs || []).find(p => p.priceUsd);
+    const wbnbUsd = Number(stablePair?.priceUsd || 0);
 
-    cache = { bnbUsd: wbnbUsd, wbnbUsd, gccUsd };
-    cacheTs = now;
-    return res.json(cache);
+    cache = { gccPerWbnb, wbnbUsd };
+    ts = Date.now();
+    res.json(cache);
   } catch (e) {
-    if (cache) return res.json(cache);
-    return res.status(502).json({ error: "price_fetch_failed" });
+    res.status(502).json({ error: "price_fetch_failed" });
   }
 });
 
-function pickBestUsd(resp, baseAddr) {
-  // Prefer quoteToken that is a USD stable (BUSD/USDT/USDC), fallback to first priceUsd provided
-  const stables = new Set(["busd", "usdt", "usdc"]);
-  const pairs = resp?.pairs || [];
-  const stable = pairs.find(p =>
-    p.baseToken?.address?.toLowerCase() === baseAddr &&
-    p.priceUsd &&
-    stables.has(p.quoteToken?.address?.toLowerCase?.() || p.quoteToken?.symbol?.toLowerCase?.())
-  );
-  const anyUsd = pairs.find(p => p.baseToken?.address?.toLowerCase() === baseAddr && p.priceUsd);
-  return Number(stable?.priceUsd || anyUsd?.priceUsd || 0);
-}
-
-function pickBestNative(resp, baseAddr) {
-  const pairs = resp?.pairs || [];
-  // Prefer pairs whose quote is WBNB (native on BSC for Dexscreener priceNative)
-  const withNative = pairs.find(p => p.baseToken?.address?.toLowerCase() === baseAddr && p.priceNative);
-  return Number(withNative?.priceNative || 0);
-}
-
 module.exports = router;
+

--- a/gcc-safeswap/packages/frontend/src/components/AppHeader.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/AppHeader.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { HeaderBadge } from './HeaderBadge.tsx';
 
 export default function AppHeader({ openSettings, account }) {
   
@@ -14,13 +15,8 @@ export default function AppHeader({ openSettings, account }) {
           <i className="icon-settings" /> Settings
         </button>
         <div className="divider" />
-        {account && <WalletChip address={account} />}
+        <HeaderBadge account={account} />
       </div>
     </header>
   );
-}
-
-function WalletChip({ address }) {
-  const display = `${address.slice(0, 6)}…${address.slice(-4)}`;
-  return <div className="pill">{display}</div>;
 }

--- a/gcc-safeswap/packages/frontend/src/components/HeaderBadge.tsx
+++ b/gcc-safeswap/packages/frontend/src/components/HeaderBadge.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { isCondor, isMetaMask, shortAddr } from "../lib/walletDetect";
+
+export function HeaderBadge({ account }: { account?: string }) {
+  const label = isCondor() ? "Condor" : (isMetaMask() ? "MetaMask" : "Wallet");
+  return (
+    <div className="chip chip--wallet">
+      <span>Wallet: {label}</span>
+      {account && <span className="addr">{shortAddr(account)}</span>}
+    </div>
+  );
+}
+

--- a/gcc-safeswap/packages/frontend/src/components/TopBar.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/TopBar.jsx
@@ -5,7 +5,7 @@ export default function TopBar({ account }) {
   const { totalUsd, bnb, gcc } = usePortfolio(account);
 
   const fmtUsd = (n) =>
-    n <= 0 ? "$0.00" :
+    n <= 0 ? "$0.0000" :
     (n < 1 ? `$${n.toFixed(4)}` : `$${n.toLocaleString(undefined, { maximumFractionDigits: 2 })}`);
 
   const fmtToken = (n, dec) => account ? n.toFixed(dec) : '—';

--- a/gcc-safeswap/packages/frontend/src/lib/pricebook.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/pricebook.ts
@@ -1,6 +1,8 @@
 const API_BASE = import.meta.env.VITE_API_BASE as string;
 
 export type Pricebook = {
+  wbnbUsd?: number;
+  gccPerWbnb?: number;
   BNB_USD?: number;
   GCC_USD?: number;
   GCC_BNB?: number;
@@ -16,15 +18,15 @@ export async function getPrices(): Promise<{ bnbUsd: number; gccUsd: number }> {
     const pb: Pricebook = await res.json();
 
     // Try multiple shapes/keys safely
-    const bnbUsd =
-      Number(pb.BNB_USD ?? pb?.prices?.BNB_USD ?? pb?.bnbUsd ?? 0) || 0;
+    const wbnbUsd =
+      Number(pb.wbnbUsd ?? pb.BNB_USD ?? pb?.prices?.BNB_USD ?? pb?.bnbUsd ?? 0) || 0;
 
-    // Prefer direct GCC_USD, else derive from GCC_BNB * BNB_USD
-    const gccUsdDirect = Number(pb.GCC_USD ?? pb?.prices?.GCC_USD ?? 0) || 0;
-    const gccBnb = Number(pb.GCC_BNB ?? pb?.prices?.GCC_BNB ?? 0) || 0;
-    const gccUsd = gccUsdDirect || (gccBnb && bnbUsd ? gccBnb * bnbUsd : 0);
+    // Prefer direct GCC_USD, else derive from gccPerWbnb * wbnbUsd
+    const gccUsdDirect = Number(pb.GCC_USD ?? pb?.prices?.GCC_USD ?? pb.gccUsd ?? 0) || 0;
+    const gccPerWbnb = Number(pb.gccPerWbnb ?? pb.GCC_BNB ?? pb?.prices?.GCC_BNB ?? 0) || 0;
+    const gccUsd = gccUsdDirect || (gccPerWbnb && wbnbUsd ? gccPerWbnb * wbnbUsd : 0);
 
-    return { bnbUsd, gccUsd };
+    return { bnbUsd: wbnbUsd, gccUsd };
   } catch (e) {
     // last-resort zeros (don't throw—avoids $0 flicker on network blips)
     return { bnbUsd: 0, gccUsd: 0 };

--- a/gcc-safeswap/packages/frontend/src/lib/walletDetect.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/walletDetect.ts
@@ -1,8 +1,14 @@
-export const isMetaMaskEnv = () => !!(window as any).ethereum?.isMetaMask;
-export const isCondorEnv   = () => !!(window as any).ethereum?.isCondor || !!(window as any).condor?.isCondor;
+export const isMetaMask = () => !!(window as any).ethereum?.isMetaMask;
+export const isCondor   = () => !!(window as any).ethereum?.isCondor || !!(window as any).condor?.isCondor;
+
+// backwards compat exports
+export const isMetaMaskEnv = isMetaMask;
+export const isCondorEnv   = isCondor;
+
+export const shortAddr = (a?: string) => (a ? `${a.slice(0,6)}…${a.slice(-4)}` : "");
 
 export const isMobileBrowser = () => /Android|iPhone|iPad|iPod/i.test(navigator.userAgent) &&
-                                     !isMetaMaskEnv(); // exclude in-app MM webview
+                                     !isMetaMask(); // exclude in-app MM webview
 
 export function buildMetaMaskDeeplink(): string {
   // dapp deeplink preserves path & query

--- a/gcc-safeswap/packages/frontend/src/styles.css
+++ b/gcc-safeswap/packages/frontend/src/styles.css
@@ -349,3 +349,8 @@ footer{ margin-top:auto; }
   .debug-log { display: none; }
   .debug-toggle { display:inline-block; padding:6px 10px; border:1px solid var(--line); border-radius:8px; }
 }
+
+/* wallet badge */
+.chip{ display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border:1px solid var(--line); border-radius:999px; font-size:.8rem; }
+.chip--wallet{ display:flex; gap:.5rem; align-items:center; }
+.chip--wallet .addr{ opacity:.8; }


### PR DESCRIPTION
## Summary
- add explicit PAIR_GCC_WBNB env support
- pin pricebook to GCC/WBNB pair with stable WBNB->USD
- display connected wallet type and address in header
- compute portfolio USD value via new pricebook pricing

## Testing
- `npm --prefix gcc-safeswap/packages/frontend run typecheck` *(fails: Cannot find module 'react')*
- `pytest` *(fails: iterator should return strings, not bytes)*

------
https://chatgpt.com/codex/tasks/task_e_68c206d27a98832b8e7f1f95b41be0d5