### PR TITLE
Prevent pricebook 500s and quiet MetaMask rejections

### DIFF
--- a/gcc-safeswap/packages/backend/server.cjs
+++ b/gcc-safeswap/packages/backend/server.cjs
@@ -68,7 +68,7 @@ app.get(["/api/plugins/health", "/plugins/health", "/health"], (_req, res) =>
 // Private RPC chain parameters
 app.use("/api/private-rpc", require("./routes/privateRpc"));
 // Token price lookup
-app.use("/api/pricebook", require("./routes/pricebook"));
+app.use(require("./routes/pricebook"));
 
 // ---------- Helpers ----------
 const _decimalsCache = new Map();
@@ -337,32 +337,6 @@ app.post("/api/relay/private", async (req, res) => {
     res
       .status(502)
       .json({ error: "relay_error", details: String(e?.message || e) });
-  }
-});
-
-app.get("/api/pricebook", async (_req, res) => {
-  try {
-    const provider = new ethers.providers.JsonRpcProvider(process.env.BSC_RPC);
-    const router   = new ethers.Contract(PCS_V2_ROUTER, PCS_V2_ABI, provider);
-
-    const oneWBNB = ethers.utils.parseUnits("1", 18);
-    const bnbOut = await router.getAmountsOut(oneWBNB, [WBNB, USDT]);
-    const bnbUsd = bnbOut[1].toString();
-
-    const oneGCC = ethers.utils.parseUnits("1", 18);
-    const gccOut = await router.getAmountsOut(oneGCC, [GCC, WBNB]);
-    const gccWbnb = gccOut[1].toString();
-
-    const gccUsd = (BigInt(gccWbnb) * BigInt(bnbUsd) / 10n**18n).toString();
-
-    res.json({
-      wbnbUsd: bnbUsd,
-      gccWbnb: gccWbnb,
-      gccUsd: gccUsd,
-      at: Date.now()
-    });
-  } catch (e) {
-    res.status(502).json({ error: "pricebook_failed", details: String(e.message || e) });
   }
 });
 

--- a/gcc-safeswap/packages/frontend/src/components/TopBar.jsx
+++ b/gcc-safeswap/packages/frontend/src/components/TopBar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePortfolio } from '../hooks/usePortfolio';
 
 export default function TopBar({ account }) {
-  const { totalUsd, bnb, gcc } = usePortfolio(account);
+  const { totalUsd, bnb, gcc, stale } = usePortfolio(account);
 
   const fmtUsd = (n) =>
     n <= 0 ? "$0.0000" :
@@ -14,7 +14,7 @@ export default function TopBar({ account }) {
     <div className="topbar badges-row">
       <BalancePill symbol="BNB" amount={fmtToken(bnb, 4)} />
       <BalancePill symbol="GCC" amount={fmtToken(gcc, 2)} />
-      <PortfolioPill usd={fmtUsd(totalUsd)} />
+      <PortfolioPill usd={fmtUsd(totalUsd)} stale={stale} />
       <RefreshButton onClick={() => window.dispatchEvent(new Event('portfolio:refresh'))} />
     </div>
   );
@@ -28,8 +28,13 @@ function BalancePill({ symbol, amount }) {
   );
 }
 
-function PortfolioPill({ usd }) {
-  return <div className="pill">Portfolio {usd}</div>;
+function PortfolioPill({ usd, stale }) {
+  return (
+    <div className="pill">
+      Portfolio {usd}
+      {stale && <span className="muted" style={{ marginLeft: 4 }}>↻ last price</span>}
+    </div>
+  );
 }
 
 function RefreshButton({ onClick }) {

--- a/gcc-safeswap/packages/frontend/src/components/WalletConnect.tsx
+++ b/gcc-safeswap/packages/frontend/src/components/WalletConnect.tsx
@@ -23,6 +23,13 @@ export function WalletConnect({ onConnected, condor, onForget }:{ onConnected:(c
                 if (!eth?.request) throw new Error("No EIP-1193 provider found");
                 await eth.request({ method: "eth_requestAccounts" });
                 onConnected();
+              } catch (e:any) {
+                if (e?.code === 4001 || /rejected/i.test(String(e?.message))) {
+                  // user canceled
+                } else {
+                  console.error(e);
+                  (window as any).showToast?.("Wallet error. Please try again.");
+                }
               } finally { setBusy(false); }
             }}
             disabled={busy}

--- a/gcc-safeswap/packages/frontend/src/hooks/usePortfolio.ts
+++ b/gcc-safeswap/packages/frontend/src/hooks/usePortfolio.ts
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { BrowserProvider } from "ethers";
 import { computePortfolioUSD } from "../lib/portfolio";
 
-type State = { totalUsd: number; bnb: number; gcc: number };
+type State = { totalUsd: number; bnb: number; gcc: number; stale: boolean };
 
 export function usePortfolio(account?: string) {
-  const [state, setState] = useState<State>({ totalUsd: 0, bnb: 0, gcc: 0 });
+  const [state, setState] = useState<State>({ totalUsd: 0, bnb: 0, gcc: 0, stale: false });
   const timer = useRef<number | null>(null);
 
   const refresh = useCallback(async () => {
@@ -27,7 +27,7 @@ export function usePortfolio(account?: string) {
       });
     } catch {}
 
-    setState({ totalUsd: res.totalUsd, bnb: res.bnb, gcc: res.gcc });
+    setState({ totalUsd: res.totalUsd, bnb: res.bnb, gcc: res.gcc, stale: res.stale });
   }, [account]);
 
   useEffect(() => {

--- a/gcc-safeswap/packages/frontend/src/lib/condorAdapter.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/condorAdapter.ts
@@ -9,19 +9,40 @@ export function getCondor(): Eip1193 | null {
   return null;
 }
 
-export async function condorConnect(): Promise<string> {
+export async function condorConnect(): Promise<string | null> {
   const c = getCondor();
   if (!c) throw new Error("Condor provider not found");
-  const accs = await c.request({ method: "eth_requestAccounts" });
-  if (!accs?.length) throw new Error("No Condor accounts");
-  return accs[0];
+  try {
+    const accs = await c.request({ method: "eth_requestAccounts" });
+    if (!accs?.length) throw new Error("No Condor accounts");
+    return accs[0];
+  } catch (e: any) {
+    if (e?.code === 4001 || /rejected/i.test(String(e?.message))) {
+      return null;
+    }
+    console.error(e);
+    (window as any).showToast?.("Wallet error. Please try again.");
+    throw e;
+  }
 }
 
-export async function condorSignRawTx(unsignedTx: any): Promise<string> {
+export async function condorSignRawTx(unsignedTx: any): Promise<string | null> {
   const c = getCondor();
   if (!c) throw new Error("Condor provider not found");
-  let raw = await c.request({ method: "eth_signTransaction", params: [unsignedTx] }).catch(() => null);
-  if (!raw) raw = await c.request({ method: "wallet_signTransaction", params: [unsignedTx] });
-  if (!/^0x[0-9a-fA-F]+$/.test(raw)) throw new Error("Condor returned non-raw tx");
-  return raw;
+  try {
+    let raw = await c
+      .request({ method: "eth_signTransaction", params: [unsignedTx] })
+      .catch(() => null);
+    if (!raw) raw = await c.request({ method: "wallet_signTransaction", params: [unsignedTx] });
+    if (!raw) return null;
+    if (!/^0x[0-9a-fA-F]+$/.test(raw)) throw new Error("Condor returned non-raw tx");
+    return raw;
+  } catch (e: any) {
+    if (e?.code === 4001 || /rejected/i.test(String(e?.message))) {
+      return null;
+    }
+    console.error(e);
+    (window as any).showToast?.("Wallet error. Please try again.");
+    throw e;
+  }
 }

--- a/gcc-safeswap/packages/frontend/src/lib/portfolio.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/portfolio.ts
@@ -1,5 +1,5 @@
 import { BrowserProvider, Contract, formatEther, formatUnits } from "ethers";
-import { getPrices } from "./pricebook";
+import { getPriceBook } from "./pricebook";
 
 const GCC = import.meta.env.VITE_TOKEN_GCC as string;
 const GCC_DECIMALS = Number(import.meta.env.VITE_GCC_DECIMALS ?? 18);
@@ -26,10 +26,12 @@ export async function computePortfolioUSD(
   provider: BrowserProvider,
   account: string
 ) {
-  const [{ bnb, gcc }, { bnbUsd, gccUsd }] = await Promise.all([
+  const [{ bnb, gcc }, pb] = await Promise.all([
     readBalances(provider, account),
-    getPrices(),
+    getPriceBook(),
   ]);
+  const bnbUsd = pb.prices?.bnbUsd ?? 0;
+  const gccUsd = pb.prices?.gccUsd ?? 0;
   const totalUsd = bnb * bnbUsd + gcc * gccUsd;
-  return { bnb, gcc, bnbUsd, gccUsd, totalUsd };
+  return { bnb, gcc, bnbUsd, gccUsd, totalUsd, stale: pb.stale };
 }

--- a/gcc-safeswap/packages/frontend/src/lib/pricebook.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/pricebook.ts
@@ -1,34 +1,25 @@
-const API_BASE = import.meta.env.VITE_API_BASE as string;
-
-export type Pricebook = {
-  wbnbUsd?: number;
-  gccPerWbnb?: number;
-  BNB_USD?: number;
-  GCC_USD?: number;
-  GCC_BNB?: number;
-  prices?: { BNB_USD?: number; GCC_USD?: number; GCC_BNB?: number };
-  // accept any other shapes the backend might return
-  [k: string]: any;
+export type PriceBook = {
+  updatedAt: string;
+  stale: boolean;
+  sources: string[];
+  prices: { bnbUsd: number; gccUsd: number; gccBnb: number };
 };
 
-export async function getPrices(): Promise<{ bnbUsd: number; gccUsd: number }> {
-  try {
-    const res = await fetch(`${API_BASE}/api/pricebook`, { cache: "no-store" });
-    if (!res.ok) throw new Error(`pricebook ${res.status}`);
-    const pb: Pricebook = await res.json();
-
-    // Try multiple shapes/keys safely
-    const wbnbUsd =
-      Number(pb.wbnbUsd ?? pb.BNB_USD ?? pb?.prices?.BNB_USD ?? pb?.bnbUsd ?? 0) || 0;
-
-    // Prefer direct GCC_USD, else derive from gccPerWbnb * wbnbUsd
-    const gccUsdDirect = Number(pb.GCC_USD ?? pb?.prices?.GCC_USD ?? pb.gccUsd ?? 0) || 0;
-    const gccPerWbnb = Number(pb.gccPerWbnb ?? pb.GCC_BNB ?? pb?.prices?.GCC_BNB ?? 0) || 0;
-    const gccUsd = gccUsdDirect || (gccPerWbnb && wbnbUsd ? gccPerWbnb * wbnbUsd : 0);
-
-    return { bnbUsd: wbnbUsd, gccUsd };
-  } catch (e) {
-    // last-resort zeros (don't throw—avoids $0 flicker on network blips)
-    return { bnbUsd: 0, gccUsd: 0 };
+export async function getPriceBook(base = import.meta.env.VITE_API_BASE as string): Promise<PriceBook> {
+  const url = `${base}/api/pricebook`;
+  for (let i = 0; i < 3; i++) {
+    try {
+      const r = await fetch(url, { cache: "no-store" });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return await r.json();
+    } catch {
+      await new Promise((r) => setTimeout(r, 250 * (i + 1)));
+    }
   }
+  return {
+    updatedAt: new Date().toISOString(),
+    stale: true,
+    sources: [],
+    prices: { bnbUsd: 0, gccUsd: 0, gccBnb: 0 },
+  };
 }

--- a/gcc-safeswap/packages/frontend/src/lib/wallet.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/wallet.ts
@@ -3,12 +3,21 @@ export function currentDappUrl() {
   return `${protocol}//${host}${pathname}${search}`.replace(/\/+$/, "");
 }
 
-export async function connectInjected() {
+export async function connectInjected(): Promise<string | null> {
   if (!window.ethereum) {
     throw new Error("No injected wallet found.");
   }
-  const accounts = await window.ethereum.request({ method: "eth_requestAccounts" });
-  return accounts[0];
+  try {
+    const accounts = await window.ethereum.request({ method: "eth_requestAccounts" });
+    return accounts[0];
+  } catch (e: any) {
+    if (e?.code === 4001 || /rejected/i.test(String(e?.message))) {
+      return null;
+    }
+    console.error(e);
+    (window as any).showToast?.("Wallet error. Please try again.");
+    throw e;
+  }
 }
 
 export function condorDeepLink(url = currentDappUrl()) {
@@ -22,12 +31,21 @@ export function getCondorProvider(win: any = window) {
   return providers.find((p: any) => p?.isCondor) || null;
 }
 
-export async function connectCondor() {
+export async function connectCondor(): Promise<string | null> {
   const prov = getCondorProvider();
   if (!prov) {
     window.open(condorDeepLink(), "_blank");
     throw new Error("Condor not found — opening deep link.");
   }
-  const accounts = await prov.request({ method: "eth_requestAccounts" });
-  return accounts[0];
+  try {
+    const accounts = await prov.request({ method: "eth_requestAccounts" });
+    return accounts[0];
+  } catch (e: any) {
+    if (e?.code === 4001 || /rejected/i.test(String(e?.message))) {
+      return null;
+    }
+    console.error(e);
+    (window as any).showToast?.("Wallet error. Please try again.");
+    throw e;
+  }
 }


### PR DESCRIPTION
## Summary
- Serve cached price data and return stale flag instead of 500s
- Display stale price hint in portfolio and retry fetching pricebook
- Swallow MetaMask user rejection errors for quieter UX

## Testing
- `cd gcc-safeswap/packages/backend && npm test` *(fails: Missing script "test")*
- `cd gcc-safeswap/packages/frontend && npm run typecheck` *(fails: Cannot find module 'react' or its types, and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c290caf480832bbccc8d2d500e6ce5