### PR TITLE
Add Condor compatibility shims

### DIFF
--- a/gcc-safeswap/packages/frontend/src/lib/condor/encoder.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/condor/encoder.ts
@@ -1,8 +1,27 @@
-import { loadCondorWallet, decodePngToPrivateKey, privateKeyToWallet } from "./condor";
+import {
+  loadCondorWallet,
+  decodePngToPrivateKey,
+  privateKeyToWallet,
+} from "./condor";
 
 /** Legacy name kept for callers that still import { loadEncoder } */
 export async function loadEncoder(): Promise<any> {
   return loadCondorWallet();
+}
+
+/** Legacy alias for older code paths (expects File | ArrayBuffer | Uint8Array). */
+export async function decodeFromPng(
+  png: File | ArrayBuffer | Uint8Array,
+  pass: string
+): Promise<string> {
+  // normalize to File | ArrayBuffer for the real helper
+  if (png instanceof Uint8Array) {
+    return decodePngToPrivateKey(
+      png.buffer.slice(png.byteOffset, png.byteOffset + png.byteLength),
+      pass
+    );
+  }
+  return decodePngToPrivateKey(png as any, pass);
 }
 
 export { decodePngToPrivateKey, privateKeyToWallet };


### PR DESCRIPTION
## Summary
- add a decodeFromPng legacy shim in the Condor encoder so older imports resolve
- restore the CondorSigner class and helper logic to keep legacy wallet flows working

## Testing
- yarn --immutable *(fails: Proxy response (403) while Corepack fetched yarn-1.22.22.tgz)*
- yarn build *(fails: Proxy response (403) while Corepack fetched yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68cbad62e32c832bbb2b515010e4b0cb