### PR TITLE
Adjust Condor signer gas buffer math

### DIFF
--- a/gcc-safeswap/packages/frontend/src/lib/condor/signer.ts
+++ b/gcc-safeswap/packages/frontend/src/lib/condor/signer.ts
@@ -90,7 +90,7 @@ export class CondorSigner {
     const limit = (
       estBig.mul
         ? estBig.mul(120).div(100)
-        : ((estBig as bigint) * 120n) / 100n
+        : (estBig * 120n) / 100n
     ) as any;
 
     return {


### PR DESCRIPTION
## Summary
- align the CondorSigner legacy gas buffer calculation with the restored compatibility shim

## Testing
- yarn --immutable *(fails: unable to download yarn-1.22.22.tgz due to restricted network access)*
- yarn build *(fails: unable to download yarn-1.22.22.tgz due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd23e126c832b8879fd57d8168f20